### PR TITLE
Typo in .config-kirkstone.yaml

### DIFF
--- a/kas/.config-kirkstone.yaml
+++ b/kas/.config-kirkstone.yaml
@@ -43,7 +43,7 @@ repos:
       meta-yocto-bsp:
   meta-rauc-community:
     url: "https://github.com/rauc/meta-rauc-community.git"
-    refspec: krikstone
+    refspec: kirkstone
     layers:
       meta-rauc-qemux86:
   meta-rauc:


### PR DESCRIPTION
Typo in branch name