### PR TITLE
Using remote sstate-cache [main]

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,5 +35,16 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates \
     gnupg \
     lsb-release
 
+# Install blobfuse2 since blobfuse1 is not avaialable in MS repos for Debian 11
+RUN sudo apt-get -y install software-properties-common \
+    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add - \
+    && sudo apt-add-repository https://packages.microsoft.com/debian/11/prod/ \
+    && sudo apt-get -y update \
+    && sudo apt-get -y install libfuse3-dev fuse3 blobfuse2
+
+# Try to enable KVM to improve performance of qemu-system-x86 on x86 hosts.
+# This is also run in post-attach.sh
+RUN /bin/bash -c "(groupadd --system kvm; gpasswd -a vscode kvm; chown root:kvm /dev/kvm; chmod 0660 /dev/kvm; echo 'KVM permissions set up') || true"
+
 # Install kas tool to set up Yocto build environment
 RUN pip3 install kas

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,13 @@
 		// Use bullseye on local arm64/Apple Silicon.
 		"args": { "VARIANT": "bullseye" }
 	},
+	"hostRequirements": {
+		"cpus": 2,
+		"memory": "4gb",
+		"storage": "128gb"
+	},
+	"postAttachCommand": ".devcontainer/post-attach.sh",
+	"postStartCommand": ".devcontainer/post-start.sh",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -33,6 +40,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
+		"docker-in-docker": "latest",
 		"github-cli": "latest"
 	}
 }

--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+# Enable KVM
+# sudo groupadd --system kvm
+# sudo gpasswd -a $USER kvm
+
+# Enable KVM Device for access to user (as qemu us run as non-root
+sudo chown root:kvm /dev/kvm
+sudo chmod 0660 /dev/kvm
+
+# Optional: Mount Azure Storage as remote sstate-cache to improve build time.
+# This is only required if you want to manually upload / sync build artifacts to your remote sstate-cache
+# To configure the sstate-cache and upload local build artifacts, the following environment variables need to be set:
+# AZURE_MOUNT_POINT="azure-sstate-cache"
+# AZURE_STORAGE_ACCESS_KEY="<Access key>"
+# AZURE_STORAGE_ACCOUNT="sdvyocto" // Replace with your storage name
+# AZURE_STORAGE_ACCOUNT_CONTAINER="yocto-sstate-cache" // Replace with your storage container name
+if [ -n "${AZURE_MOUNT_POINT}" ] && [ -n "${AZURE_STORAGE_ACCOUNT_CONTAINER}" ]; then
+    [ -d ${AZURE_MOUNT_POINT} ] || mkdir -p ${AZURE_MOUNT_POINT}
+    if $(blobfuse2 mount list | grep -q "${AZURE_MOUNT_POINT}"); then
+        echo "Unmounting remote sstate-cache: ${AZURE_MOUNT_POINT}"
+        blobfuse2 --disable-version-check unmount ${AZURE_MOUNT_POINT}
+    fi
+    TEMPD=$(mktemp -d)
+    echo "Mounting remote sstate-cache on Azure Storage Account ${AZURE_STORAGE_ACCOUNT_CONTAINER} to local path: ${AZURE_MOUNT_POINT}"
+    blobfuse2 --disable-version-check mount ${AZURE_MOUNT_POINT} --log-level LOG_DEBUG --use-https=true --tmp-path=$TEMPD --container-name=${AZURE_STORAGE_ACCOUNT_CONTAINER} || true
+else
+    echo "Warning: No AZURE_MOUNT_POINT or no AZURE_STORAGE_ACCOUNT_CONTAINER set for remote sstate-cache."
+fi

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+git clone https://github.com/openembedded/bitbake
+bitbake/bin/bitbake-hashserv -b :1234 &

--- a/.github/workflows/leda-utils.yml
+++ b/.github/workflows/leda-utils.yml
@@ -32,4 +32,4 @@ jobs:
         git clone https://github.com/openembedded/bitbake
         bitbake/bin/bitbake-hashserv -b :1234 &
     - name: Build leda-utils
-      run: kas build ./.config.yaml:kas/mirrors.yaml --target sdv-core-utils
+      run: kas build kas/.config-kirkstone.yaml:kas/mirrors.yaml --target sdv-core-utils

--- a/.github/workflows/leda-utils.yml
+++ b/.github/workflows/leda-utils.yml
@@ -27,23 +27,9 @@ jobs:
       run: sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq libvirt-clients libvirt-daemon-system qemu-system-x86 qemu-system-arm qemu-kvm squashfs-tools rauc python3-newt ca-certificates curl gnupg lsb-release
     - name: Install kas
       run: sudo pip3 install kas
-    - name: Cache Downloads
-      id: cache-downloads
-      uses: actions/cache@v3
-      with:
-        path: build/downloads
-        key: bb-downloads
-    - name: Cache SState
-      id: cache-sstate
-      uses: actions/cache@v3
-      with:
-        path: build/sstate-cache
-        key: bb-sstate-cache
-    - name: Cache Local
-      id: cache-local
-      uses: actions/cache@v3
-      with:
-        path: build/cache
-        key: bb-cache-local
+    - name: Start BitBake Hash Equivalence Server
+      run: |
+        git clone https://github.com/openembedded/bitbake
+        bitbake/bin/bitbake-hashserv -b :1234 &
     - name: Build leda-utils
-      run: kas build --target sdv-core-utils
+      run: kas build ./.config.yaml:kas/mirrors.yaml --target sdv-core-utils

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ meta-rauc
 meta-rauc-community
 meta-virtualization
 poky
+
+# BitBake Hash Equivalence Server database
+hashserv.db*

--- a/kas/mirrors.yaml
+++ b/kas/mirrors.yaml
@@ -1,0 +1,25 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# Every file needs to contain a header, that provides kas with information
+# about the context of this file.
+header:
+  # The `version` entry in the header describes for which configuration
+  # format version this file was created for. It is used by kas to figure
+  # out if it is compatible with this file. The version is an integer that
+  # is increased on every format change.
+  version: 12
+# The machine as it is written into the `local.conf` of bitbake.
+local_conf_header:
+  mirror: |
+    BB_HASHSERVE = "127.0.0.1:1234"
+    SSTATE_MIRRORS = "file://.* https://sdvyocto.blob.core.windows.net/yocto-sstate-cache/sstate-cache/PATH"

--- a/meta-leda-distro-container/recipes-sdv/sdv-containers/cloudagent-container_git.bb
+++ b/meta-leda-distro-container/recipes-sdv/sdv-containers/cloudagent-container_git.bb
@@ -14,8 +14,7 @@
 SUMMARY = "SDV Cloud Connector container image"
 DESCRIPTION = "Docker container of the Eclipse Kanto Cloud Connector for IoT Suite"
 
-SRC_URI += "file://README.txt \
-            file://LICENSE"
+SRC_URI += "file://LICENSE"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"


### PR DESCRIPTION
To use the optional remote cache for sstate-cache, add the kas/mirrors.yaml file to the invocation of kas:

    kas build kas/.config-kirkstone.yaml:kas/mirrors.yaml

