### PR TITLE
Remove ALSA from distro image

### DIFF
--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -37,7 +37,7 @@ function azure-mount() {
         else
             TEMPD=$(mktemp -d)
             echo "Mounting remote Azure Storage ${AZURE_STORAGE_ACCOUNT_CONTAINER} to local path: ${AZURE_MOUNT_POINT}"
-            blobfuse2 --disable-version-check mount ${AZURE_MOUNT_POINT} --log-level LOG_DEBUG --use-https=true --tmp-path=$TEMPD --container-name=${AZURE_STORAGE_ACCOUNT_CONTAINER} || true
+            blobfuse2 --disable-version-check mount ${AZURE_MOUNT_POINT} --use-https=true --tmp-path=$TEMPD --container-name=${AZURE_STORAGE_ACCOUNT_CONTAINER} || true
         fi
     else
         echo "Warning: No AZURE_MOUNT_POINT or no AZURE_STORAGE_ACCOUNT_CONTAINER set for mounting."

--- a/.github/workflows/auto-cherry-pick.yaml
+++ b/.github/workflows/auto-cherry-pick.yaml
@@ -1,3 +1,18 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: Cherry-Pick Bot
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/generate-mirror.yml
+++ b/.github/workflows/generate-mirror.yml
@@ -46,7 +46,10 @@ jobs:
       run: sudo pip3 install kas
     - name: Fetch all
       continue-on-error: true
-      run: kas shell -c 'bitbake --continue --runall=fetch sdv-image-all' kas/generate-mirror.yaml
+      run: |
+        KAS_MACHINE=qemux86-64 kas shell -c 'bitbake --continue --runall=fetch sdv-image-all' kas/generate-mirror.yaml
+        KAS_MACHINE=qemuarm64 kas shell -c 'bitbake --continue --runall=fetch sdv-image-all' kas/generate-mirror.yaml
+        KAS_MACHINE=raspberrypi4-64 kas shell -c 'bitbake --continue --runall=fetch sdv-image-all' kas/generate-mirror.yaml
     - name: List archives
       continue-on-error: true
       run: ls -al build/downloads/
@@ -55,6 +58,6 @@ jobs:
       with:
         source_dir: 'build/downloads/'
         container_name: 'downloads'
-        extra_args: '--pattern *.tar.gz'
-        overwrite: 'true'
+        extra_args: '--pattern *.tar.*'
+        overwrite: 'sync'
         connection_string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}

--- a/.github/workflows/generate-mirror.yml
+++ b/.github/workflows/generate-mirror.yml
@@ -31,7 +31,7 @@ name: Generate Yocto Mirror
 on:
   workflow_dispatch:
   schedule:
-    - cron: '37 13 * * SUN'
+    - cron: '35 13 * * SUN'
 
 jobs:
   generate-mirror:
@@ -47,6 +47,9 @@ jobs:
     - name: Fetch all
       continue-on-error: true
       run: kas shell -c 'bitbake --continue --runall=fetch sdv-image-all' kas/generate-mirror.yaml
+    - name: List archives
+      continue-on-error: true
+      run: ls -al build/downloads/
     - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
       if: ${{ github.repository_owner == 'SoftwareDefinedVehicle' }}
       with:

--- a/.github/workflows/generate-mirror.yml
+++ b/.github/workflows/generate-mirror.yml
@@ -1,44 +1,57 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+#
+# Download all the sources of the Leda / Yocto packages, create a tar ball 
+# in the build/downloads and upload the *.tar.gz files to the remote downloads mirror.
+# - Runs every Sunday
+# - Archives the source from upstream repositories
+# - Synchronizes to remote mirror on Azure Storage
+# - Optimizes build time 
+# - Prevents slow repositories from slowing down the build
+# - Prevents build failures due to offline upstream repositories or temporary unavailability
+# - Decreases load on upstream repositories
+# - Typical size of mirror is about 15GB
+#
+# Slow repositories are:
+# - sourceware.org (binutils, cross-localedef)
+# - git.yoctoproject.org (linux-yocto)
+#
 name: Generate Yocto Mirror
+
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '37 13 * * SUN'
+
 jobs:
   generate-mirror:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install tools
       run: |
-        sudo apt-get update
         sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq libvirt-clients libvirt-daemon-system qemu-system-x86 qemu-system-arm qemu-kvm squashfs-tools rauc python3-newt ca-certificates curl gnupg lsb-release
     - name: Install kas
       run: sudo pip3 install kas
-    - name: Cache Downloads
-      id: cache-downloads
-      uses: actions/cache@v3
-      with:
-        path: build/downloads
-        key: bb-downloads
-    - name: Cache SState
-      id: cache-sstate
-      uses: actions/cache@v3
-      with:
-        path: build/sstate-cache
-        key: bb-sstate-cache
-    - name: Cache Local
-      id: cache-local
-      uses: actions/cache@v3
-      with:
-        path: build/cache
-        key: bb-cache-local
     - name: Fetch all
       continue-on-error: true
       run: kas shell -c 'bitbake --continue --runall=fetch sdv-image-all' kas/generate-mirror.yaml
-    - uses: LanceMcCarthy/Action-AzureBlobUpload@v2
-      name: Update remote download mirror
+    - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+      if: ${{ github.repository_owner == 'SoftwareDefinedVehicle' }}
       with:
+        source_dir: 'build/downloads/'
+        container_name: 'downloads'
+        extra_args: '--pattern *.tar.gz'
+        overwrite: 'true'
         connection_string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
-        container_name: downloads
-        source_folder: build/downloads/
-        destination_folder: /
-

--- a/.github/workflows/generate-mirror.yml
+++ b/.github/workflows/generate-mirror.yml
@@ -58,6 +58,6 @@ jobs:
       with:
         source_dir: 'build/downloads/'
         container_name: 'downloads'
-        extra_args: '--pattern *.tar.*'
+        extra_args: '--pattern *.tar.*[!done]'
         overwrite: 'sync'
         connection_string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}

--- a/.github/workflows/leda-utils.yml
+++ b/.github/workflows/leda-utils.yml
@@ -27,24 +27,6 @@ jobs:
       run: sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq libvirt-clients libvirt-daemon-system qemu-system-x86 qemu-system-arm qemu-kvm squashfs-tools rauc python3-newt ca-certificates curl gnupg lsb-release
     - name: Install kas
       run: sudo pip3 install kas
-    - name: Cache Downloads
-      id: cache-downloads
-      uses: actions/cache@v3
-      with:
-        path: build/downloads
-        key: bb-downloads
-    - name: Cache SState
-      id: cache-sstate
-      uses: actions/cache@v3
-      with:
-        path: build/sstate-cache
-        key: bb-sstate-cache
-    - name: Cache Local
-      id: cache-local
-      uses: actions/cache@v3
-      with:
-        path: build/cache
-        key: bb-cache-local
     - name: Start BitBake Hash Equivalence Server
       run: |
         git clone https://github.com/openembedded/bitbake

--- a/docs/setup-kas.md
+++ b/docs/setup-kas.md
@@ -17,3 +17,14 @@ To build a specific target, recipe or image, execute this:
 
     kas build --target packagegroup-sdv-core
 
+To use a downloads and hashserv mirror, include the mirror configuration:
+
+    kas build kas/.config-kirkstone.yaml:kas/mirrors.yaml
+
+To perform a dry-run of the build:
+
+    kas build kas/.config-kirkstone.yaml:kas/mirrors.yaml -- --dryrun
+
+To execute QEMU:
+
+    kas shell -c "runqemu kvm ovmf nographic" kas/.config-kirkstone.yaml

--- a/kas/generate-mirror.yaml
+++ b/kas/generate-mirror.yaml
@@ -19,7 +19,7 @@ header:
   # is increased on every format change.
   version: 12
   includes:
-    - .config-kirkstone.yaml
+    - kas/.config-kirkstone.yaml
 # The machine as it is written into the `local.conf` of bitbake.
 task: fetch
 target: sdv-image-all

--- a/meta-leda-components/recipes-sdv/sdv-base/sdv-core-utils_0.1.bb
+++ b/meta-leda-components/recipes-sdv/sdv-base/sdv-core-utils_0.1.bb
@@ -15,7 +15,7 @@ SUMMARY = "SDV Core Utilities"
 DESCRIPTION = "Core shell scripts"
 
 SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
-SRCREV = "64ad53ff4b952735ebc5e051e00aad39938ca4a0"
+SRCREV = "586ef6da1b841efd76fb06b9821bae4277e325e0"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"

--- a/meta-leda-distro/conf/distro/include/leda-package-blacklist.inc
+++ b/meta-leda-distro/conf/distro/include/leda-package-blacklist.inc
@@ -1,0 +1,16 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# A list of packages which will not be included in a Leda distribution
+
+SKIP_RECIPE[alsa] ?= "ALSA is blacklisted to save build time and storage"
+PACKAGE_EXCLUDE += "alsa"

--- a/meta-leda-distro/conf/distro/leda.conf
+++ b/meta-leda-distro/conf/distro/leda.conf
@@ -15,9 +15,11 @@ require conf/distro/poky.conf
 
 require conf/distro/include/buildinfo.inc
 require conf/distro/include/leda-distro-features.inc
-require conf/distro/include/leda-selfupdate-rauc.inc
-require conf/distro/include/leda-qemu-settings.inc
+require conf/distro/include/leda-install-packages.inc
 require conf/distro/include/leda-oss-compliance.inc
+require conf/distro/include/leda-package-blacklist.inc
+require conf/distro/include/leda-qemu-settings.inc
+require conf/distro/include/leda-selfupdate-rauc.inc
 
 # Potential machine-specific overrides, supporting patches to existing meta layers
 # Example is "meta-leda/conf/machine/raspberrypi4-64-extra.conf" which


### PR DESCRIPTION
ALSA is a package which we don't need to the SDV quickstart images, it just takes up unnecessary space.