### PR TITLE
nerdctl SRC_URI fix for kirkstone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ meta-rauc
 meta-rauc-community
 meta-virtualization
 poky
+
+# Azure Cache
+azure-sstate-cache
+bitbake

--- a/meta-leda-distro/recipes-container/nerdctl/nerdctl_git.bbappend
+++ b/meta-leda-distro/recipes-container/nerdctl/nerdctl_git.bbappend
@@ -1,0 +1,21 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# Branch has been renamed from master to main in upstream repository
+
+inherit go
+
+SRC_URI:remove = "git://github.com/containerd/nerdctl.git;name=nerdcli;branch=master;protocol=https"
+
+# Appending will not work, as the main SRC_URI checkout will clear the target directory and then
+# the vendor.fetch folder will be missing. Hence, prepending the new url to the list of SRC_URIs.
+SRC_URI =+ "git://github.com/containerd/nerdctl.git;name=nerdcli;branch=main;protocol=https"


### PR DESCRIPTION
The nerdctl SRC_URI branch name fix was applied to the main branch of meta-virtualization, but not for release branches such as kirkstone. This recipe fixes the SRC_URI for meta-virtualization kirkstone.