### PR TITLE
Build components independently of Leda distro

### DIFF
--- a/.github/workflows/sdv-core-components.yml
+++ b/.github/workflows/sdv-core-components.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Update apt
+      run: sudo apt-get update -y
     - name: Install tools
       run: sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev zstd liblz4-tool python3-newt ca-certificates curl gnupg lsb-release
     - name: Install kas

--- a/.github/workflows/sdv-core-components.yml
+++ b/.github/workflows/sdv-core-components.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Update apt
       run: sudo apt-get update -y
     - name: Install tools
-      run: sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev zstd liblz4-tool python3-newt ca-certificates curl gnupg lsb-release
+      run: sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd liblz4-tool python3-newt ca-certificates curl gnupg lsb-release
     - name: Install kas
       run: sudo pip3 install kas
     - name: Build SDV core components only (poky distro)

--- a/.github/workflows/sdv-core-components.yml
+++ b/.github/workflows/sdv-core-components.yml
@@ -1,0 +1,31 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: SDV Core
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  leda-core:
+    name: SDV Core
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install tools
+      run: sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev zstd liblz4-tool python3-newt ca-certificates curl gnupg lsb-release
+    - name: Install kas
+      run: sudo pip3 install kas
+    - name: Build SDV core components only (poky distro)
+      run: kas build kas/.config-components.yaml:kas/mirrors.yaml

--- a/kas/.config-components.yaml
+++ b/kas/.config-components.yaml
@@ -1,0 +1,58 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# Every file needs to contain a header, that provides kas with information
+# about the context of this file.
+header:
+  # The `version` entry in the header describes for which configuration
+  # format version this file was created for. It is used by kas to figure
+  # out if it is compatible with this file. The version is an integer that
+  # is increased on every format change.
+  version: 12
+# The machine as it is written into the `local.conf` of bitbake.
+# machine: qemux86-64
+# The distro name as it is written into the `local.conf` of bitbake.
+target:
+  - packagegroup-sdv-core
+local_conf_header:
+  needed-features: |
+    DISTRO_FEATURES += " rauc virtualization"
+    INHERIT += " rm_work"
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    refspec: kirkstone
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    refspec: kirkstone
+    layers:
+      meta-oe:
+      meta-filesystems:
+      meta-python:
+      meta-networking:
+  meta-rauc:
+    url: "https://github.com/rauc/meta-rauc.git"
+    refspec: kirkstone
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"
+    refspec: kirkstone
+  meta-kanto:
+    url: "https://github.com/eclipse-kanto/meta-kanto.git"
+    refspec: kirkstone
+  meta-leda:
+    path: ./
+    layers:
+      meta-leda-components:

--- a/kas/.config-components.yaml
+++ b/kas/.config-components.yaml
@@ -23,6 +23,9 @@ header:
 # The distro name as it is written into the `local.conf` of bitbake.
 target:
   - packagegroup-sdv-core
+  - packagegroup-sdv-additions
+  - packagegroup-sdv-examples
+  - packagegroup-sdv-tools
 local_conf_header:
   needed-features: |
     DISTRO_FEATURES += " rauc virtualization"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer.inc
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer.inc
@@ -12,10 +12,11 @@
 # ********************************************************************************/
 
 
-PACKAGES = "${PN}"
+PACKAGES = "${PN} ${PN}-dbg"
 FILES:${PN} += "${bindir}/kanto-auto-deployer"
 FILES:${PN} += "${systemd_unitdir}/system/kanto-auto-deployer.service"
 FILES:${PN} += "${KANTO_MANIFESTS_DIR}"
+FILES:${PN}-dbg += "${bindir}/.debug"
 
 do_install:append() {
 	cargo_do_install

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kantui.inc
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kantui.inc
@@ -12,8 +12,9 @@
 # ********************************************************************************/
 
 
-PACKAGES = "${PN}"
+PACKAGES = "${PN} ${PN}-dbg"
 FILES:${PN} += "${bindir}/kantui"
+FILES:${PN}-dbg += "${bindir}/.debug"
 
 do_install:append() {
 	cargo_do_install

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
@@ -29,4 +29,4 @@ RDEPENDS:${PN} = "\
 "
 
 # TODO: For future example applictations:
-# gspd gpsd-conf
+# gpsd gpsd-conf


### PR DESCRIPTION
The recipes in meta-leda/meta-components are supposed to be buildable independently of a Leda distro, as other users of the metalayer usually have their own distro anyway.

We need to ensure that our core recipes can be reused outside of the Leda-distro-specific configurations.

This PR is a first step towards building single recipes with "poky" as a default distro.