### PR TITLE
Cleanup packagegroup structure

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
@@ -26,8 +26,8 @@ inherit cargo kanto-auto-deployer
 RDEPENDS_${PN} += " grpc protobuf nativesdk-protobuf"
 DEPENDS += " protobuf protobuf-native grpc git-native"
 
-SRCREV = "e4882a8e64f6d172f212a241c58aa66e58faa741"
-PV:append = ".AUTOINC+e4882a8e64f"
+SRCREV = "467e4cebd86dcfee686b1e676ed0f30ca741354a"
+PV:append = ".AUTOINC+467e4cebd86"
 SRC_URI = "gitsm://github.com/eclipse-leda/leda-utils;protocol=https;nobranch=0;branch=main"
 
 S = "${WORKDIR}/git"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/seatservice.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/seatservice.json
@@ -1,8 +1,8 @@
 {
     "id": "",
-    "name": "databroker",
+    "name": "seatservice",
     "image": {
-        "name": "ghcr.io/eclipse/kuksa.val/databroker:0.2.5",
+        "name": "ghcr.io/eclipse/kuksa.val.services/seat_service:v0.1.0",
         "decrypt_config": null
     },
     "host_name": "",
@@ -23,7 +23,15 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [],
-        "port_mappings": [],
+        "port_mappings": [
+            {
+              "protocol": "tcp",
+              "container_port": 50051,
+              "host_ip": "localhost",
+              "host_port": 50051,
+              "host_port_end": 50051
+            }
+        ],
         "log_config": {
             "driver_config": {
                 "type": "json-file",
@@ -46,7 +54,12 @@
         "stdin_once": false,
         "tty": false
     },
-    "config": null,
+    "config": {
+        "env": [
+           "VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker"
+        ],
+        "cmd": []
+    },
     "network_settings": null,
     "state": {
         "pid": -1,

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/sua.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/sua.json
@@ -1,8 +1,8 @@
 {
     "id": "",
-    "name": "databroker",
+    "name": "sua",
     "image": {
-        "name": "ghcr.io/eclipse/kuksa.val/databroker:0.2.5",
+        "name": "ghcr.io/eclipse-leda/leda-contrib-self-update-agent/sua:testing",
         "decrypt_config": null
     },
     "host_name": "",
@@ -10,7 +10,18 @@
     "resolv_conf_path": "",
     "hosts_path": "",
     "hostname_path": "",
-    "mounts": [],
+    "mounts": [
+        {
+            "source": "/var/run/dbus/system_bus_socket",
+            "destination": "/var/run/dbus/system_bus_socket",
+            "propagation_mode": "rprivate"
+        },
+        {
+            "source": "/data_temp/selfupdates",
+            "destination": "/RaucUpdate",
+            "propagation_mode": "rprivate"
+        }
+    ],
     "hooks": [],
     "host_config": {
         "devices": [],
@@ -22,8 +33,18 @@
             "type": "unless-stopped"
         },
         "runtime": "io.containerd.runc.v2",
-        "extra_hosts": [],
-        "port_mappings": [],
+        "extra_hosts": [
+            "mosquitto:host_ip"
+        ],
+        "port_mappings": [
+            {
+              "protocol": "tcp",
+              "container_port": 50052,
+              "host_ip": "localhost",
+              "host_port": 50052,
+              "host_port_end": 50052
+            }
+        ],
         "log_config": {
             "driver_config": {
                 "type": "json-file",
@@ -46,7 +67,13 @@
         "stdin_once": false,
         "tty": false
     },
-    "config": null,
+    "config": {
+        "env": [
+           "MQTT_CONN_BROKER=tcp://mosquitto:1883",
+           "LOG_LEVEL=INFO"
+        ],
+        "cmd": []
+    },
     "network_settings": null,
     "state": {
         "pid": -1,

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/vum.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/vum.json
@@ -1,8 +1,8 @@
 {
     "id": "",
-    "name": "databroker",
+    "name": "vum",
     "image": {
-        "name": "ghcr.io/eclipse/kuksa.val/databroker:0.2.5",
+        "name": "ghcr.io/eclipse-leda/leda-contrib-vehicle-update-manager/vehicleupdatemanager:main-1d8dca55a755c4b3c7bc06eabfa06ad49e068a48",
         "decrypt_config": null
     },
     "host_name": "",
@@ -22,7 +22,9 @@
             "type": "unless-stopped"
         },
         "runtime": "io.containerd.runc.v2",
-        "extra_hosts": [],
+        "extra_hosts": [
+            "mosquitto:host_ip"
+        ],
         "port_mappings": [],
         "log_config": {
             "driver_config": {
@@ -46,7 +48,15 @@
         "stdin_once": false,
         "tty": false
     },
-    "config": null,
+    "config": {
+        "env": [
+           "MQTT_CONN_BROKER=tcp://mosquitto:1883",
+           "LOG_LEVEL=INFO",
+           "SELF_UPDATE_TIMEOUT=30m",
+           "SELF_UPDATE_ENABLE_REBOOT=true"
+        ],
+        "cmd": []
+    },
     "network_settings": null,
     "state": {
         "pid": -1,

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-default-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-default-containers.bb
@@ -18,11 +18,22 @@ SRC_URI += "file://LICENSE"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
+# Will be changed for sua.json as well and be separated in a different recipe
+SUA_DATA_DIR = "/data_temp/selfupdates"
+
 do_install:append() {
     install -d ${D}${KANTO_MANIFESTS_DIR}
     install ${THISDIR}/kanto-containers/databroker.json ${D}${KANTO_MANIFESTS_DIR}
+    install ${THISDIR}/kanto-containers/seatservice.json ${D}${KANTO_MANIFESTS_DIR}
+    install ${THISDIR}/kanto-containers/vum.json ${D}${KANTO_MANIFESTS_DIR}
+    mkdir -p ${D}${SUA_DATA_DIR}
+    install ${THISDIR}/kanto-containers/sua.json ${D}${KANTO_MANIFESTS_DIR}
 }
 
 PACKAGES = "${PN}"
 FILES:${PN} += "${KANTO_MANIFESTS_DIR}/databroker.json"
+FILES:${PN} += "${KANTO_MANIFESTS_DIR}/seatservice.json"
+FILES:${PN} += "${KANTO_MANIFESTS_DIR}/vum.json"
+FILES:${PN} += "${SUA_DATA_DIR}"
+FILES:${PN} += "${KANTO_MANIFESTS_DIR}/sua.json"
 

--- a/meta-leda-components/recipes-sdv/packagegroups/README.md
+++ b/meta-leda-components/recipes-sdv/packagegroups/README.md
@@ -1,0 +1,37 @@
+# Eclipse Leda - Metalayer - Package Groups
+
+## Core
+
+Minimum set of required system components to run an SDV.EDGE stack:
+- Container Runtime
+- RAUC Update Service for OTA Self Update
+- Mosquitto
+- Default Containers, e.g. Data Broker
+
+## Additions
+
+Additional system components which makes it easier to implement additional use cases or experiments:
+- Kanto: Suite Connector, File-Upload, System-Metrics etc.
+- Northstar: northstar daemon
+- SSH server
+- RAUC Hawkbit Connector
+- OpenVPN
+
+## Examples
+
+Example applications and dependencies (such as CAN drivers) which are predeployed for quickstart tutorials.
+- Seat Service incl. CAN Utils
+
+## Tools
+
+Convenient tools for developing or troubleshooting:
+- Basic system tools: htop, jq, nano, sudo
+- Mosquitto Utilities: mosquitto-clients
+- Leda Utilities: sdv-core-utils
+- Container tools: skopeo, kantui, northstar nstar
+
+## Rescue
+
+System components needed to perform a "rescue" case, such as resetting the device to factory settings or reestablishing the cloud registration
+- SSH Server
+- RAUC

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
@@ -17,14 +17,14 @@ DESCRIPTION = "Packages required to set up a basic working demo SDV system, but 
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
-    container-management \
     file-upload \
     file-backup \
     software-update \
     suite-connector \
     system-metrics \
     rauc-hawkbit-updater \
-    kanto-auto-deployer \
-    sdv-default-containers \
-    kantui \
+    openssh \
+    openssh-sftp-server \
+    openvpn \
+    northstar \
 "

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-core.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-core.bb
@@ -18,9 +18,9 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     ca-certificates \
-    openssh \
-    openssh-sftp-server \
     rauc \
-    sdv-core-utils \
-    openvpn \
+    mosquitto \
+    container-management \
+    kanto-auto-deployer \
+    sdv-default-containers \
     "

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-rescue.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-rescue.bb
@@ -18,4 +18,5 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     ca-certificates \
+    openssh \
     rauc "

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-tools.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-tools.bb
@@ -24,4 +24,6 @@ RDEPENDS:${PN} = "\
     sdv-core-utils \
     skopeo \
     sudo \
+    kantui \
+    northstar-nstar \
     "

--- a/meta-leda-components/recipes-sdv/sdv-base/sdv-core-utils_0.1.bb
+++ b/meta-leda-components/recipes-sdv/sdv-base/sdv-core-utils_0.1.bb
@@ -15,7 +15,7 @@ SUMMARY = "SDV Core Utilities"
 DESCRIPTION = "Core shell scripts"
 
 SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
-SRCREV = "586ef6da1b841efd76fb06b9821bae4277e325e0"
+SRCREV = "c816c3a75dcc41a2962d34730b9fd0bc0084c79d"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-rescue.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-rescue.bb
@@ -18,7 +18,7 @@ IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL}"
 IMAGE_INSTALL:append = " kernel-image kernel-modules"
 
 # Rescue system only contains self-update-agent and cloud connector
-IMAGE_INSTALL:append = " packagegroup-sdv-core-direct"
+IMAGE_INSTALL:append = " packagegroup-sdv-rescue"
 
 IMAGE_FEATURES:append = " read-only-rootfs"
 


### PR DESCRIPTION
The packagegroups of sdv recipes are not properly separated yet.

In this PR, i give a proposal on how to separate the packagegroups to make them more easy to reuse for specific images:
- Core: minimum set of core system components to run the SDV.EDGE stack, eg container runtime, mosquitto, rauc etc
- Additions: additional components to ease additional use cases, eg ssh server, openvpn, alternative container runtime
- Examples: example applications such as the seat service
- Tools: Convenient tools for developing and troubleshooting
- Rescue: Tools for implementing a rescue use case ("Reset Device to Factory Settings")

Except for the "Core" packagegroup, all other components are supposed to be optional.
The Core packagegroup must only contain the absolute minimum to get the edge stack up and running.
Otherwise, the reusability of the metalayer is at risk.
