### PR TITLE
Optimize data partition

### DIFF
--- a/.config.yaml
+++ b/.config.yaml
@@ -29,6 +29,7 @@ local_conf_header:
     INHERIT:remove = " archiver"
     INHERIT:remove = " cve-check"
     INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+    KANTO_MANIFESTS_DIR = "/data/var/containers/manifests"
   meta-rauc: |
     RAUC_KEY_FILE = "${COREBASE}/../examples/rauc/development-1.key.pem"
     RAUC_CERT_FILE = "${COREBASE}/../examples/rauc/development-1.cert.pem"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer.inc
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer.inc
@@ -15,6 +15,7 @@
 PACKAGES = "${PN}"
 FILES:${PN} += "${bindir}/kanto-auto-deployer"
 FILES:${PN} += "${systemd_unitdir}/system/kanto-auto-deployer.service"
+FILES:${PN} += "${KANTO_MANIFESTS_DIR}"
 
 do_install:append() {
 	cargo_do_install

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
@@ -25,7 +25,6 @@ RDEPENDS:${PN} = "\
     system-metrics \
     rauc-hawkbit-updater \
     kanto-auto-deployer \
-    sdv-default-containers \
     kantui \
 "
 

--- a/meta-leda-distro/conf/distro/leda.conf
+++ b/meta-leda-distro/conf/distro/leda.conf
@@ -41,6 +41,7 @@ REPRODUCIBLE_TIMESTAMP_ROOTFS = ""
 RM_WORK_EXCLUDE += " sdv-image-full"
 RM_WORK_EXCLUDE += " sdv-image-minimal"
 RM_WORK_EXCLUDE += " sdv-image-rescue"
+RM_WORK_EXCLUDE += " sdv-image-data"
 RM_WORK_EXCLUDE += " sdv-image-all"
 RM_WORK_EXCLUDE += " sdv-rauc-bundle"
 

--- a/meta-leda-distro/recipes-containers/containerd/containerd-opencontainers_%.bbappend
+++ b/meta-leda-distro/recipes-containers/containerd/containerd-opencontainers_%.bbappend
@@ -1,0 +1,11 @@
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://config.toml"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/containerd
+    install -m 0644 ${WORKDIR}/config.toml ${D}${sysconfdir}/containerd/config.toml
+}
+
+FILES:${PN} += "${sysconfdir}/containerd/config.toml"

--- a/meta-leda-distro/recipes-containers/containerd/files/config.toml
+++ b/meta-leda-distro/recipes-containers/containerd/files/config.toml
@@ -1,0 +1,1 @@
+root = "/data/var/containerd"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-all.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-all.bb
@@ -20,8 +20,8 @@ IMAGE_FEATURES:append = " allow-empty-password"
 IMAGE_FEATURES:append = " empty-root-password"
 
 # The image dependencies are actually both types: build-time and run-time dependency
-RDEPENDS:${PN} = "sdv-image-full sdv-image-minimal sdv-image-rescue sdv-rauc-bundle"
-DEPENDS = "sdv-image-full sdv-image-minimal sdv-image-rescue sdv-rauc-bundle"
+RDEPENDS:${PN} = "sdv-image-full sdv-image-minimal sdv-image-rescue sdv-image-data sdv-rauc-bundle"
+DEPENDS = "sdv-image-full sdv-image-minimal sdv-image-rescue sdv-image-data sdv-rauc-bundle"
 
 inherit core-image
 
@@ -33,6 +33,7 @@ inherit core-image
 do_image_wic[depends] += "sdv-image-rescue:do_rootfs_wicenv"
 do_image_wic[depends] += "sdv-image-minimal:do_rootfs_wicenv"
 do_image_wic[depends] += "sdv-image-full:do_rootfs_wicenv"
+do_image_wic[depends] += "sdv-image-data:do_rootfs_wicenv"
 
 # For qemu, we produce disk images in qcow2 format (faster and smaller than raw or ext4 images)
 IMAGE_FSTYPES = " wic.qcow2"
@@ -57,3 +58,9 @@ QB_FSINFO:qemuarm64 = "wic:no-kernel-in-fs"
 #  WIC Kickstarter File: build-sdv-arm-qemu/wic/qemuarm-grub.wks
 QB_KERNEL_ROOT = "/dev/vda4"
 QB_DRIVE_TYPE = "/dev/vd"
+
+
+# inherit overlayfs
+# OVERLAYFS_MOUNT_POINT[data] = "/data/var/lib"
+# OVERLAYFS_WRITABLE_PATHS[data] = "/var/lib"
+# OVERLAYFS_QA_SKIP[varlib] = "mount-configured"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-data.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-data.bb
@@ -1,0 +1,48 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+SUMMARY = "An image containing files for the SDV data partition."
+LICENSE = "Apache-2.0"
+
+
+# TODO: Temporarily disabled AirGap container installations
+# until projects have released containers
+# IMAGE_INSTALL:append = " packagegroup-sdv-airgap"
+
+
+IMAGE_INSTALL += "sdv-default-containers"
+
+
+IMAGE_FSTYPES += "ext4.gz"
+IMAGE_LINGUAS = ""
+IMAGE_ROOTFS_SIZE ?= "4194304"
+
+IMAGE_PREPROCESS_COMMAND += "prepare_filesystem;"
+
+inherit image
+
+CONTAINER_DIR = "/var/containers"
+
+prepare_filesystem() {
+    install -d ${IMAGE_ROOTFS}/var/containerd/
+
+    install -d ${IMAGE_ROOTFS}${CONTAINER_DIR}
+    mv "${IMAGE_ROOTFS}${KANTO_MANIFESTS_DIR}" "${IMAGE_ROOTFS}${CONTAINER_DIR}"
+
+    rm -rf ${IMAGE_ROOTFS}/etc/systemd
+    rm -rf ${IMAGE_ROOTFS}/etc/ld.so.cache
+    rm -rf ${IMAGE_ROOTFS}/run
+    rm -rf ${IMAGE_ROOTFS}/var/cache
+    rm -rf ${IMAGE_ROOTFS}/var/lib
+    rm -rf ${IMAGE_ROOTFS}/data
+}

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
@@ -24,12 +24,10 @@ IMAGE_INSTALL:append = " packagegroup-sdv-additions"
 IMAGE_INSTALL:append = " packagegroup-sdv-tools"
 IMAGE_INSTALL:append = " packagegroup-sdv-examples"
 
-# TODO: Temporarily disabled AirGap container installations
-# until projects have released containers
-# IMAGE_INSTALL:append = " packagegroup-sdv-airgap"
-
 IMAGE_LINGUAS = " "
 
+# IMAGE_FEATURES:append = " read-only-rootfs"
+# IMAGE_INSTALL:append = " volatile-binds"
 
 # Debug tweaks
 IMAGE_FEATURES:append = " debug-tweaks"

--- a/meta-leda-distro/wic/qemuarm.wks
+++ b/meta-leda-distro/wic/qemuarm.wks
@@ -42,4 +42,4 @@ part --fixed-size 2500M --source rootfs --rootfs-dir=sdv-image-full --ondisk vda
 part --fixed-size 2500M --source rootfs --rootfs-dir=sdv-image-minimal  --ondisk vda --fstype=ext4 --label root_b --align 4096
 
 # Data partition for k3s (/dev/vda6)
-part --fixed-size 4096M --ondisk vda --fstype=ext4 --label data --align 4096
+part --fixed-size 4096M --source rootfs --rootfs-dir=sdv-image-data --ondisk vda --fstype=ext4 --label data --align 4096

--- a/meta-leda-distro/wic/qemuarm64.wks
+++ b/meta-leda-distro/wic/qemuarm64.wks
@@ -35,4 +35,4 @@ part --fixed-size 10M --ondisk vda --align 4096
 part --fixed-size 150M --source rootfs --rootfs-dir=sdv-image-rescue --ondisk vda --fstype=ext4 --label rescue --align 1024
 part --fixed-size 2500M --source rootfs --rootfs-dir=sdv-image-full --ondisk vda --fstype=ext4 --label root_a --align 4096
 part --fixed-size 2500M --source rootfs --rootfs-dir=sdv-image-minimal  --ondisk vda --fstype=ext4 --label root_b --align 4096
-part --fixed-size 4096M --ondisk vda --fstype=ext4 --label data --align 4096
+part --fixed-size 4096M --source rootfs --rootfs-dir=sdv-image-data --ondisk vda --fstype=ext4 --label data --align 4096

--- a/meta-leda-distro/wic/qemux86-grub-efi.wks
+++ b/meta-leda-distro/wic/qemux86-grub-efi.wks
@@ -44,4 +44,4 @@ part --fixed-size 2500M --source rootfs --rootfs-dir=sdv-image-minimal --ondisk 
 
 # The data partition to store Kubernetes Cluster state (e.g. containerized apps)
 # Last partition, so that it can be grown (eg on Raspi to full SD-Card capacitiy, on qemu by extending the qcow2 disk image file)
-part --fixed-size 4096M --ondisk vda --fstype=ext4 --label data
+part --fixed-size 4096M --source rootfs --rootfs-dir=sdv-image-data --ondisk vda --fstype=ext4 --label data

--- a/meta-leda-distro/wic/raspberrypi.wks.in
+++ b/meta-leda-distro/wic/raspberrypi.wks.in
@@ -34,4 +34,4 @@ part --fixed-size 2500M --source rootfs --rootfs-dir=sdv-image-full --ondisk mmc
 part --fixed-size 2500M --source rootfs --rootfs-dir=sdv-image-minimal  --ondisk mmcblk0 --fstype=ext4 --label root_b --align 4096
 
 # /dev/mmcblk0p6 - Kubernetes Data partition mounted to "/data"
-part --fixed-size 4096M --ondisk mmcblk0 --fstype=ext4 --label data --align 4096  --fsoptions "x-systemd.growfs"
+part --fixed-size 4096M --source rootfs --rootfs-dir=sdv-image-data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --fsoptions "x-systemd.growfs"


### PR DESCRIPTION
As a preparation to make the root filesystems (full and minimal image) read-only, as it would be on a production system, we introduce a new data partition which contains (also persistent) runtime data and configuration data.
- New image recipe for the data partition. Workaround using bind-auto-mounting on /var can be removed
- Container manifests for initial auto-deployment are now located on the data partition
- containerd's working directory is now moved to /data/var/containerd
