### PR TITLE
New name for 2023 release

### DIFF
--- a/meta-leda-distro-container/conf/distro/leda-container.conf
+++ b/meta-leda-distro-container/conf/distro/leda-container.conf
@@ -16,7 +16,7 @@ require conf/distro/poky.conf
 DISTRO = "leda-container"
 DISTRO_NAME = "Eclipse Leda Container Image"
 DISTRO_VERSION = "1.0"
-DISTRO_CODENAME = "Hockenheim"
+DISTRO_CODENAME = "Miglia"
 MAINTAINER = "Eclise Leda Developers <leda-dev@eclipse.org>"
 
 DISTRO_FEATURES = "acl ipv4 ipv6 largefile xattr ${DISTRO_FEATURES_LIBC}"

--- a/meta-leda-distro/conf/distro/leda.conf
+++ b/meta-leda-distro/conf/distro/leda.conf
@@ -28,8 +28,8 @@ include conf/machine/${MACHINE}-extra.conf
 
 DISTRO = "leda"
 DISTRO_NAME="Eclipse Leda"
-DISTRO_VERSION="2022"
-DISTRO_CODENAME="Hockenheim"
+DISTRO_VERSION="2023"
+DISTRO_CODENAME="Dracon"
 
 MAINTAINER = "Eclipse Leda Committers <leda-dev@eclipse.org>"
 


### PR DESCRIPTION
New release name for the 2023 release of Leda will be "Dracon", which is a race track in Bulgaria.