### PR TITLE
Fix network unit generation from kernel command line

### DIFF
--- a/meta-leda-distro/conf/distro/leda.conf
+++ b/meta-leda-distro/conf/distro/leda.conf
@@ -45,4 +45,4 @@ RM_WORK_EXCLUDE += " sdv-image-data"
 RM_WORK_EXCLUDE += " sdv-image-all"
 RM_WORK_EXCLUDE += " sdv-rauc-bundle"
 
-QB_KERNEL_CMDLINE_APPEND = "net.ifnames=0 panic=5 ip=dhcp ip=192.168.7.2::192.168.7.1:255.255.255.0 rootwait"
+QB_KERNEL_CMDLINE_APPEND = "net.ifnames=0 panic=5 ip=dhcp ip=192.168.7.2::192.168.7.1:255.255.255.0::eth0:off rootwait"


### PR DESCRIPTION
Ref: https://linuxlink.timesys.com/docs/static_ip

Our kernel seems to not be compiled with the features to autoconfigure its network via rootp/bootp. Omitting the value for autoconfig sets it to "both" as default though.

That's why it was set manually to off. Also a network interface was specified since (citing the ref. above): 

> If this entry is empty, all devices are used, and the first device responding is configured.

Otherwise,  booting with this kernel command line gives us:

```shell
root@qemuarm64:~# systemctl status systemd-network-generator.service
* systemd-network-generator.service - Generate network units from Kernel command line
     Loaded: loaded (/lib/systemd/system/systemd-network-generator.service; enabled; vendor preset: enabled)
     Active: active (exited) since Wed 2023-01-11 12:51:13 UTC; 36s ago
       Docs: man:systemd-network-generator.service(8)
    Process: 146 ExecStart=/lib/systemd/systemd-network-generator (code=exited, status=0/SUCCESS)
   Main PID: 146 (code=exited, status=0/SUCCESS)
```

and

```shell
root@qemuarm64:~# ifconfig
can0      Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  
          UP RUNNING NOARP  MTU:16  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:10 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
          Interrupt:62 

eth0      Link encap:Ethernet  HWaddr 52:54:00:12:35:02  
          inet addr:192.168.7.2  Bcast:192.168.7.255  Mask:255.255.255.0
          inet6 addr: fec0::5054:ff:fe12:3502/64 Scope:Site
          inet6 addr: fe80::5054:ff:fe12:3502/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:8 errors:0 dropped:0 overruns:0 frame:0
          TX packets:89 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:1053 (1.0 KiB)  TX bytes:5229 (5.1 KiB)

kanto-cm0 Link encap:Ethernet  HWaddr 02:42:0E:BE:50:91  
          inet addr:172.17.0.1  Bcast:172.17.255.255  Mask:255.255.0.0
          UP BROADCAST MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:371 errors:0 dropped:0 overruns:0 frame:0
          TX packets:371 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:31763 (31.0 KiB)  TX bytes:31763 (31.0 KiB)
```

=> Everything functions correctly now.