### PR TITLE
Fixed cloud connector systemd dependency

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-cloud-connector_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-cloud-connector_git.bb
@@ -31,7 +31,7 @@ S = "${WORKDIR}/git"
 do_compile[network] = "1"
 
 inherit go-mod
-inherit systemd features_check
+inherit systemd
 
 NATIVE_SYSTEMD_SUPPORT = "1"
 SYSTEMD_PACKAGES = "${PN}"
@@ -45,8 +45,6 @@ FILES:${PN} += " \
   ${sysconfdir}/${PGM_NAME}/iothub.crt \
 "
 
-REQUIRED_DISTRO_FEATURES = "systemd"
-
 do_compile() {
   cd ${B}/src/${GO_IMPORT}
   ${GO} build ${GOBUILDFLAGS} -o ${B}/${PGM_NAME} ./cmd/
@@ -56,8 +54,10 @@ do_install() {
   install -d "${D}/${bindir}"
   install -m 0755 "${B}/${PGM_NAME}" "${D}/${bindir}"
 
-  install -d ${D}${systemd_unitdir}/system/
-  install -m 0644 ${WORKDIR}/${PGM_NAME}/cloud-connector.service ${D}${systemd_system_unitdir}
+  if [ "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}" ]; then
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/${PGM_NAME}/cloud-connector.service ${D}${systemd_system_unitdir}
+  fi
 
   install -d "${D}/${sysconfdir}/${PGM_NAME}"
   install -m 0644 "${WORKDIR}/${PGM_NAME}/config.json" "${D}${sysconfdir}/${PGM_NAME}"


### PR DESCRIPTION
The native installation of leda-contrib-cloud-connector had a strong dependency to systemd, which is not really necessary.

Only the systemd-related service unit files require systemd, and the cloud-connector binary and config files can also be started in other ways, if the user wants to do that. For the sake of reusability of the recipe, the change makes the recipe's dependency to systemd optional, like many other bitbake recipes do it.

The systemd service unit for the cloud-connector are only installed when DISTRO_FEATURES contains "systemd"