### PR TITLE
Default for KANTO_MANIFESTS_DIR

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/classes/kanto-auto-deployer.bbclass
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/classes/kanto-auto-deployer.bbclass
@@ -11,4 +11,8 @@
 # * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 #
+
 KANTO_MANIFESTS_LOCAL_DIR ??= "/var/containers/manifests"
+
+KANTO_MANIFESTS_DIR ??= "${KANTO_MANIFESTS_LOCAL_DIR}"
+KANTO_MANIFESTS_DIR[doc] = "The location path of Kanto Container Management deployment descriptors to autodeploy"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer.inc
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer.inc
@@ -64,6 +64,10 @@ install_service() {
     install -d ${D}${KANTO_SERVICE_DIR}
     install -m 0644 ${THISDIR}/files/kanto-auto-deployer.service.template ${D}${KANTO_SERVICE_DIR}/kanto-auto-deployer.service
 
+    if [ -z ${KANTO_MANIFESTS_DIR} ]; then
+        bbfatal "KANTO_MANIFESTS_DIR must not be empty, please set in your local.conf"
+    fi
+
     # fill in the kanto auto deployer service template with the result configurations
     sed -e 's,@KD_BIN_DD@,${bindir},g' \
         -e 's,@KD_CFG_DD@,${KANTO_MANIFESTS_DIR},g' \


### PR DESCRIPTION
Setting the default of KANTO_MANIFESTS_DIR

If the value is empty, a build warning will occur.
