### PR TITLE
Readded debug package for rust apps

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
@@ -37,7 +37,7 @@ DEPENDS += "glib-networking"
 DEPENDS += "nlohmann-json"
 DEPENDS += "paho-mqtt-cpp"
 
-PACKAGES = "${PN}-data ${PN}"
+PACKAGES = "${PN}-data ${PN} ${PN}-dbg"
 
 SYSTEMD_SERVICE:${PN} = "self-update-agent.service"
 
@@ -49,6 +49,10 @@ FILES:${PN} += " \
 
 FILES:${PN}-data += " \
     /data/self-update-images/ \
+"
+
+FILES:${PN}-dbg += " \
+    ${bindir}/.debug/ \
 "
 
 do_install() {


### PR DESCRIPTION
The cargo bbclass will by default also create debug packages.

In the Leda distribution, we disabled building debug packages, but when building with other distros (eg Poky), then the debug package is requested, but FILES:${PN}-dbg did not specify the debug binary in ${bindir}/.debug, which lead to the installed-vs-shipped QA error.