### PR TITLE
Fix databroker cli

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli.inc
+++ b/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli.inc
@@ -14,3 +14,7 @@
 # Include file for Kuksa Databroker Command Line Tool
 
 DESCRIPTION = "Eclipse Kuksa - DataBroker command line tool to interact with the databroker server"
+
+do_compile:prepend() {
+    rm ${S}/Cargo.lock
+}

--- a/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
@@ -31,8 +31,11 @@ do_compile:prepend(){
     # toolchain version > 1.59.0. This causes the bitbake recipe to fail with a 
     # missing dependency. Deleting the lock causes the OE meta-rust tasks to
     # re-generate the Cargo.lock with the crate versions.
-    rm "${S}/Cargo.lock"
+    if [ -f "${S}/Cargo.lock" ]; then
+        rm "${S}/Cargo.lock"
+    fi
 }
+
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched
 SRC_URI += " \

--- a/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
@@ -21,11 +21,18 @@ inherit cargo
 # how to get databroker-cli could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/databroker-cli/0.17.0"
 SRC_URI += "gitsm://github.com/eclipse/kuksa.val;protocol=https;nobranch=1"
-SRCREV = "6d2f7b97e2f5817830ef333a636d90138a18b9b1"
+SRCREV = "590198a35de7b2201bdd913750157bb9778a5214"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "kuksa_databroker/databroker-cli"
 PV:append = ".AUTOINC+861b2ec674"
 
+do_compile:prepend(){
+    # Needed as the repo for kuksa provides a Cargo.lock generated with a Rust 
+    # toolchain version > 1.59.0. This causes the bitbake recipe to fail with a 
+    # missing dependency. Deleting the lock causes the OE meta-rust tasks to
+    # re-generate the Cargo.lock with the crate versions.
+    rm "${S}/Cargo.lock"
+}
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched
 SRC_URI += " \
@@ -59,7 +66,6 @@ SRC_URI += " \
     crate://crates.io/fixedbitset/0.4.2 \
     crate://crates.io/fnv/1.0.7 \
     crate://crates.io/form_urlencoded/1.1.0 \
-    crate://crates.io/fs_extra/1.2.0 \
     crate://crates.io/futures-channel/0.3.25 \
     crate://crates.io/futures-core/0.3.25 \
     crate://crates.io/futures-sink/0.3.25 \
@@ -68,7 +74,7 @@ SRC_URI += " \
     crate://crates.io/getrandom/0.1.16 \
     crate://crates.io/getrandom/0.2.8 \
     crate://crates.io/getset/0.1.2 \
-    crate://crates.io/git2/0.15.0 \
+    crate://crates.io/git2/0.14.2 \
     crate://crates.io/h2/0.3.15 \
     crate://crates.io/hashbrown/0.12.3 \
     crate://crates.io/heck/0.3.3 \
@@ -84,12 +90,10 @@ SRC_URI += " \
     crate://crates.io/instant/0.1.12 \
     crate://crates.io/itertools/0.10.5 \
     crate://crates.io/itoa/1.0.5 \
-    crate://crates.io/jemalloc-sys/0.5.2+5.3.0-patched \
-    crate://crates.io/jemallocator/0.5.0 \
     crate://crates.io/jobserver/0.1.25 \
     crate://crates.io/lazy_static/1.4.0 \
     crate://crates.io/libc/0.2.139 \
-    crate://crates.io/libgit2-sys/0.14.1+1.5.0 \
+    crate://crates.io/libgit2-sys/0.13.2+1.4.2 \
     crate://crates.io/libz-sys/1.1.8 \
     crate://crates.io/linefeed/0.6.0 \
     crate://crates.io/log/0.4.17 \
@@ -103,6 +107,7 @@ SRC_URI += " \
     crate://crates.io/nom/5.1.2 \
     crate://crates.io/nu-ansi-term/0.46.0 \
     crate://crates.io/num_cpus/1.15.0 \
+    crate://crates.io/num_threads/0.1.6 \
     crate://crates.io/once_cell/1.17.0 \
     crate://crates.io/os_str_bytes/6.4.1 \
     crate://crates.io/overload/0.1.1 \
@@ -162,9 +167,7 @@ SRC_URI += " \
     crate://crates.io/thiserror-impl/1.0.38 \
     crate://crates.io/thiserror/1.0.38 \
     crate://crates.io/thread_local/1.1.4 \
-    crate://crates.io/time-core/0.1.0 \
-    crate://crates.io/time-macros/0.2.6 \
-    crate://crates.io/time/0.3.17 \
+    crate://crates.io/time/0.3.15 \
     crate://crates.io/tinyvec/1.6.0 \
     crate://crates.io/tinyvec_macros/0.1.0 \
     crate://crates.io/tokio-io-timeout/1.2.0 \
@@ -191,7 +194,7 @@ SRC_URI += " \
     crate://crates.io/unicode-width/0.1.10 \
     crate://crates.io/url/2.3.1 \
     crate://crates.io/vcpkg/0.2.15 \
-    crate://crates.io/vergen/7.5.0 \
+    crate://crates.io/vergen/7.3.2 \
     crate://crates.io/version_check/0.9.4 \
     crate://crates.io/want/0.3.0 \
     crate://crates.io/wasi/0.11.0+wasi-snapshot-preview1 \
@@ -209,7 +212,6 @@ SRC_URI += " \
     crate://crates.io/windows_x86_64_gnullvm/0.42.0 \
     crate://crates.io/windows_x86_64_msvc/0.42.0 \
 "
-
 
 LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=2b42edef8fa55315f34f2370b4715ca9 \

--- a/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
@@ -21,7 +21,7 @@ inherit cargo
 # how to get databroker-cli could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/databroker-cli/0.17.0"
 SRC_URI += "gitsm://github.com/eclipse/kuksa.val;protocol=https;nobranch=1"
-SRCREV = "590198a35de7b2201bdd913750157bb9778a5214"
+SRCREV = "6d2f7b97e2f5817830ef333a636d90138a18b9b1"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "kuksa_databroker/databroker-cli"
 PV:append = ".AUTOINC+861b2ec674"
@@ -29,108 +29,109 @@ PV:append = ".AUTOINC+861b2ec674"
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched
 SRC_URI += " \
-    crate://crates.io/aho-corasick/0.7.18 \
+    crate://crates.io/aho-corasick/0.7.20 \
     crate://crates.io/ansi_term/0.12.1 \
-    crate://crates.io/anyhow/1.0.59 \
+    crate://crates.io/anyhow/1.0.68 \
     crate://crates.io/arrayref/0.3.6 \
     crate://crates.io/arrayvec/0.5.2 \
     crate://crates.io/async-stream-impl/0.3.3 \
     crate://crates.io/async-stream/0.3.3 \
-    crate://crates.io/async-trait/0.1.57 \
+    crate://crates.io/async-trait/0.1.61 \
     crate://crates.io/autocfg/1.1.0 \
-    crate://crates.io/base64/0.13.0 \
+    crate://crates.io/base64/0.13.1 \
     crate://crates.io/bitflags/1.3.2 \
     crate://crates.io/blake2b_simd/0.5.11 \
-    crate://crates.io/bumpalo/3.10.0 \
-    crate://crates.io/bytes/1.2.1 \
-    crate://crates.io/cc/1.0.73 \
+    crate://crates.io/bytes/1.3.0 \
+    crate://crates.io/cc/1.0.78 \
     crate://crates.io/cfg-if/0.1.10 \
     crate://crates.io/cfg-if/1.0.0 \
-    crate://crates.io/clap/3.2.16 \
+    crate://crates.io/clap/3.2.23 \
     crate://crates.io/clap_lex/0.2.4 \
     crate://crates.io/constant_time_eq/0.1.5 \
-    crate://crates.io/crossbeam-utils/0.8.11 \
+    crate://crates.io/crossbeam-utils/0.8.14 \
     crate://crates.io/dirs-sys/0.3.7 \
     crate://crates.io/dirs/1.0.5 \
     crate://crates.io/dirs/2.0.2 \
-    crate://crates.io/either/1.7.0 \
-    crate://crates.io/enum-iterator-derive/1.0.2 \
-    crate://crates.io/enum-iterator/1.1.3 \
+    crate://crates.io/either/1.8.0 \
+    crate://crates.io/enum-iterator-derive/1.1.0 \
+    crate://crates.io/enum-iterator/1.2.0 \
     crate://crates.io/fastrand/1.8.0 \
     crate://crates.io/fixedbitset/0.4.2 \
     crate://crates.io/fnv/1.0.7 \
-    crate://crates.io/form_urlencoded/1.0.1 \
-    crate://crates.io/futures-channel/0.3.21 \
-    crate://crates.io/futures-core/0.3.21 \
-    crate://crates.io/futures-sink/0.3.21 \
-    crate://crates.io/futures-task/0.3.21 \
-    crate://crates.io/futures-util/0.3.21 \
+    crate://crates.io/form_urlencoded/1.1.0 \
+    crate://crates.io/fs_extra/1.2.0 \
+    crate://crates.io/futures-channel/0.3.25 \
+    crate://crates.io/futures-core/0.3.25 \
+    crate://crates.io/futures-sink/0.3.25 \
+    crate://crates.io/futures-task/0.3.25 \
+    crate://crates.io/futures-util/0.3.25 \
     crate://crates.io/getrandom/0.1.16 \
-    crate://crates.io/getrandom/0.2.7 \
+    crate://crates.io/getrandom/0.2.8 \
     crate://crates.io/getset/0.1.2 \
-    crate://crates.io/git2/0.14.4 \
-    crate://crates.io/h2/0.3.13 \
+    crate://crates.io/git2/0.15.0 \
+    crate://crates.io/h2/0.3.15 \
     crate://crates.io/hashbrown/0.12.3 \
     crate://crates.io/heck/0.3.3 \
-    crate://crates.io/hermit-abi/0.1.19 \
+    crate://crates.io/hermit-abi/0.2.6 \
     crate://crates.io/http-body/0.4.5 \
     crate://crates.io/http/0.2.8 \
-    crate://crates.io/httparse/1.7.1 \
+    crate://crates.io/httparse/1.8.0 \
     crate://crates.io/httpdate/1.0.2 \
     crate://crates.io/hyper-timeout/0.4.1 \
-    crate://crates.io/hyper/0.14.20 \
-    crate://crates.io/idna/0.2.3 \
-    crate://crates.io/indexmap/1.9.1 \
+    crate://crates.io/hyper/0.14.23 \
+    crate://crates.io/idna/0.3.0 \
+    crate://crates.io/indexmap/1.9.2 \
     crate://crates.io/instant/0.1.12 \
-    crate://crates.io/itertools/0.10.3 \
-    crate://crates.io/itoa/1.0.3 \
-    crate://crates.io/jobserver/0.1.24 \
-    crate://crates.io/js-sys/0.3.59 \
+    crate://crates.io/itertools/0.10.5 \
+    crate://crates.io/itoa/1.0.5 \
+    crate://crates.io/jemalloc-sys/0.5.2+5.3.0-patched \
+    crate://crates.io/jemallocator/0.5.0 \
+    crate://crates.io/jobserver/0.1.25 \
     crate://crates.io/lazy_static/1.4.0 \
-    crate://crates.io/libc/0.2.127 \
-    crate://crates.io/libgit2-sys/0.13.4+1.4.2 \
+    crate://crates.io/libc/0.2.139 \
+    crate://crates.io/libgit2-sys/0.14.1+1.5.0 \
     crate://crates.io/libz-sys/1.1.8 \
     crate://crates.io/linefeed/0.6.0 \
     crate://crates.io/log/0.4.17 \
     crate://crates.io/matchers/0.1.0 \
-    crate://crates.io/matches/0.1.9 \
     crate://crates.io/memchr/2.5.0 \
     crate://crates.io/memoffset/0.6.5 \
-    crate://crates.io/mio/0.8.4 \
+    crate://crates.io/mio/0.8.5 \
     crate://crates.io/mortal/0.2.3 \
     crate://crates.io/multimap/0.8.3 \
-    crate://crates.io/nix/0.23.1 \
+    crate://crates.io/nix/0.23.2 \
     crate://crates.io/nom/5.1.2 \
-    crate://crates.io/num_cpus/1.13.1 \
-    crate://crates.io/num_threads/0.1.6 \
-    crate://crates.io/once_cell/1.13.0 \
-    crate://crates.io/os_str_bytes/6.2.0 \
-    crate://crates.io/percent-encoding/2.1.0 \
+    crate://crates.io/nu-ansi-term/0.46.0 \
+    crate://crates.io/num_cpus/1.15.0 \
+    crate://crates.io/once_cell/1.17.0 \
+    crate://crates.io/os_str_bytes/6.4.1 \
+    crate://crates.io/overload/0.1.1 \
+    crate://crates.io/percent-encoding/2.2.0 \
     crate://crates.io/petgraph/0.6.2 \
     crate://crates.io/phf/0.8.0 \
     crate://crates.io/phf_codegen/0.8.0 \
     crate://crates.io/phf_generator/0.8.0 \
     crate://crates.io/phf_shared/0.8.0 \
-    crate://crates.io/pin-project-internal/1.0.11 \
+    crate://crates.io/pin-project-internal/1.0.12 \
     crate://crates.io/pin-project-lite/0.2.9 \
-    crate://crates.io/pin-project/1.0.11 \
+    crate://crates.io/pin-project/1.0.12 \
     crate://crates.io/pin-utils/0.1.0 \
-    crate://crates.io/pkg-config/0.3.25 \
-    crate://crates.io/ppv-lite86/0.2.16 \
+    crate://crates.io/pkg-config/0.3.26 \
+    crate://crates.io/ppv-lite86/0.2.17 \
     crate://crates.io/proc-macro-error-attr/1.0.4 \
     crate://crates.io/proc-macro-error/1.0.4 \
-    crate://crates.io/proc-macro2/1.0.43 \
+    crate://crates.io/proc-macro2/1.0.49 \
     crate://crates.io/prost-build/0.9.0 \
     crate://crates.io/prost-derive/0.9.0 \
     crate://crates.io/prost-types/0.9.0 \
     crate://crates.io/prost/0.9.0 \
-    crate://crates.io/quote/1.0.21 \
+    crate://crates.io/quote/1.0.23 \
     crate://crates.io/rand/0.7.3 \
     crate://crates.io/rand/0.8.5 \
     crate://crates.io/rand_chacha/0.2.2 \
     crate://crates.io/rand_chacha/0.3.1 \
     crate://crates.io/rand_core/0.5.1 \
-    crate://crates.io/rand_core/0.6.3 \
+    crate://crates.io/rand_core/0.6.4 \
     crate://crates.io/rand_hc/0.2.0 \
     crate://crates.io/rand_pcg/0.2.1 \
     crate://crates.io/redox_syscall/0.1.57 \
@@ -138,76 +139,75 @@ SRC_URI += " \
     crate://crates.io/redox_users/0.3.5 \
     crate://crates.io/redox_users/0.4.3 \
     crate://crates.io/regex-automata/0.1.10 \
-    crate://crates.io/regex-syntax/0.6.27 \
-    crate://crates.io/regex/1.6.0 \
+    crate://crates.io/regex-syntax/0.6.28 \
+    crate://crates.io/regex/1.7.1 \
     crate://crates.io/remove_dir_all/0.5.3 \
     crate://crates.io/rust-argon2/0.8.3 \
-    crate://crates.io/rustversion/1.0.9 \
-    crate://crates.io/ryu/1.0.11 \
-    crate://crates.io/serde/1.0.142 \
-    crate://crates.io/serde_json/1.0.83 \
+    crate://crates.io/rustversion/1.0.11 \
+    crate://crates.io/ryu/1.0.12 \
+    crate://crates.io/serde/1.0.152 \
+    crate://crates.io/serde_json/1.0.91 \
     crate://crates.io/sharded-slab/0.1.4 \
     crate://crates.io/signal-hook-registry/1.4.0 \
     crate://crates.io/siphasher/0.3.10 \
     crate://crates.io/slab/0.4.7 \
     crate://crates.io/smallstr/0.2.0 \
-    crate://crates.io/smallvec/1.9.0 \
-    crate://crates.io/socket2/0.4.4 \
+    crate://crates.io/smallvec/1.10.0 \
+    crate://crates.io/socket2/0.4.7 \
     crate://crates.io/sqlparser/0.16.0 \
-    crate://crates.io/syn/1.0.99 \
+    crate://crates.io/syn/1.0.107 \
     crate://crates.io/tempfile/3.3.0 \
     crate://crates.io/terminfo/0.7.3 \
-    crate://crates.io/textwrap/0.15.0 \
-    crate://crates.io/thiserror-impl/1.0.32 \
-    crate://crates.io/thiserror/1.0.32 \
+    crate://crates.io/textwrap/0.16.0 \
+    crate://crates.io/thiserror-impl/1.0.38 \
+    crate://crates.io/thiserror/1.0.38 \
     crate://crates.io/thread_local/1.1.4 \
-    crate://crates.io/time/0.3.12 \
+    crate://crates.io/time-core/0.1.0 \
+    crate://crates.io/time-macros/0.2.6 \
+    crate://crates.io/time/0.3.17 \
     crate://crates.io/tinyvec/1.6.0 \
     crate://crates.io/tinyvec_macros/0.1.0 \
     crate://crates.io/tokio-io-timeout/1.2.0 \
-    crate://crates.io/tokio-macros/1.8.0 \
-    crate://crates.io/tokio-stream/0.1.9 \
+    crate://crates.io/tokio-macros/1.8.2 \
+    crate://crates.io/tokio-stream/0.1.11 \
     crate://crates.io/tokio-util/0.6.10 \
-    crate://crates.io/tokio-util/0.7.3 \
-    crate://crates.io/tokio/1.20.1 \
+    crate://crates.io/tokio-util/0.7.4 \
+    crate://crates.io/tokio/1.24.1 \
     crate://crates.io/tonic-build/0.6.2 \
     crate://crates.io/tonic/0.6.2 \
-    crate://crates.io/tower-layer/0.3.1 \
+    crate://crates.io/tower-layer/0.3.2 \
     crate://crates.io/tower-service/0.3.2 \
     crate://crates.io/tower/0.4.13 \
-    crate://crates.io/tracing-attributes/0.1.22 \
-    crate://crates.io/tracing-core/0.1.29 \
+    crate://crates.io/tracing-attributes/0.1.23 \
+    crate://crates.io/tracing-core/0.1.30 \
     crate://crates.io/tracing-futures/0.2.5 \
-    crate://crates.io/tracing-subscriber/0.3.15 \
-    crate://crates.io/tracing/0.1.36 \
-    crate://crates.io/try-lock/0.2.3 \
+    crate://crates.io/tracing-subscriber/0.3.16 \
+    crate://crates.io/tracing/0.1.37 \
+    crate://crates.io/try-lock/0.2.4 \
     crate://crates.io/unicode-bidi/0.3.8 \
-    crate://crates.io/unicode-ident/1.0.3 \
-    crate://crates.io/unicode-normalization/0.1.21 \
-    crate://crates.io/unicode-segmentation/1.9.0 \
-    crate://crates.io/unicode-width/0.1.9 \
-    crate://crates.io/url/2.2.2 \
+    crate://crates.io/unicode-ident/1.0.6 \
+    crate://crates.io/unicode-normalization/0.1.22 \
+    crate://crates.io/unicode-segmentation/1.10.0 \
+    crate://crates.io/unicode-width/0.1.10 \
+    crate://crates.io/url/2.3.1 \
     crate://crates.io/vcpkg/0.2.15 \
-    crate://crates.io/vergen/7.3.2 \
+    crate://crates.io/vergen/7.5.0 \
     crate://crates.io/version_check/0.9.4 \
     crate://crates.io/want/0.3.0 \
     crate://crates.io/wasi/0.11.0+wasi-snapshot-preview1 \
     crate://crates.io/wasi/0.9.0+wasi-snapshot-preview1 \
-    crate://crates.io/wasm-bindgen-backend/0.2.82 \
-    crate://crates.io/wasm-bindgen-macro-support/0.2.82 \
-    crate://crates.io/wasm-bindgen-macro/0.2.82 \
-    crate://crates.io/wasm-bindgen-shared/0.2.82 \
-    crate://crates.io/wasm-bindgen/0.2.82 \
-    crate://crates.io/which/4.2.5 \
+    crate://crates.io/which/4.3.0 \
     crate://crates.io/winapi-i686-pc-windows-gnu/0.4.0 \
     crate://crates.io/winapi-x86_64-pc-windows-gnu/0.4.0 \
     crate://crates.io/winapi/0.3.9 \
-    crate://crates.io/windows-sys/0.36.1 \
-    crate://crates.io/windows_aarch64_msvc/0.36.1 \
-    crate://crates.io/windows_i686_gnu/0.36.1 \
-    crate://crates.io/windows_i686_msvc/0.36.1 \
-    crate://crates.io/windows_x86_64_gnu/0.36.1 \
-    crate://crates.io/windows_x86_64_msvc/0.36.1 \
+    crate://crates.io/windows-sys/0.42.0 \
+    crate://crates.io/windows_aarch64_gnullvm/0.42.0 \
+    crate://crates.io/windows_aarch64_msvc/0.42.0 \
+    crate://crates.io/windows_i686_gnu/0.42.0 \
+    crate://crates.io/windows_i686_msvc/0.42.0 \
+    crate://crates.io/windows_x86_64_gnu/0.42.0 \
+    crate://crates.io/windows_x86_64_gnullvm/0.42.0 \
+    crate://crates.io/windows_x86_64_msvc/0.42.0 \
 "
 
 

--- a/meta-leda-components/recipes-sdv/eclipse-kuksa/readme.txt
+++ b/meta-leda-components/recipes-sdv/eclipse-kuksa/readme.txt
@@ -4,11 +4,14 @@ The [Eclipse Kuksa.VAL Databroker](https://github.com/eclipse/kuksa.val/tree/mas
 Cargo-BitBake (see https://github.com/meta-rust/cargo-bitbake) is used to generate recipes for Rust applications using Cargo.
 
 Pre-Requisites:
+- Install Rust and Cargo: `curl https://sh.rustup.rs -sSf | sh`
+- Source the environment: `source "$HOME/.cargo/env"`
 - Install OpenSSL development package: `sudo apt install libssl-dev`
 - Install the Cargo BitBake Recipe Generator: `cargo install --locked cargo-bitbake`
 - Checkout the sources manually once: `git clone https://github.com/eclipse/kuksa.val`
 - Switch to the source directory: `cd kuksa.val/kuksa_databroker/databroker-cli`
+- Add the "repository" field to the config.toml (into the [package] section), pointing to the git src url
 - Run the generator: `cargo bitbake`
-- Copy the generated .bb file to the target metalayer: `cp databroker-cli_*.bb ../../meta-yourlayer/recipes-core/
+- Compare or copy the generated .bb file to the target metalayer: `cp databroker-cli_*.bb .../meta-leda-components/recipes-sdv/eclipse-kuksa`
 - Adapt the databroker-cli_<version>.bb file and update the license filename and license file checksum
 - If you need to add custom build functions, create the file `databroker-cli.inc` and include the steps there

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-tools.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-tools.bb
@@ -24,6 +24,7 @@ RDEPENDS:${PN} = "\
     sdv-core-utils \
     skopeo \
     sudo \
+    databroker-cli \
     "
 
 # TODO: For future example applictations


### PR DESCRIPTION
# Issue

The databroker-cli fails to build with the provided in the root of the cargo-workspace Cargo.lock, since this lock was generated with a Rust version newer than 1.59.0.

This leads to problems with the dependency resolution during the compilation.

# Solution

Delete the repository-provided Cargo.lock, thus causing the bitbake Rust compilation tasks to re-generate it with dependencies matching the used Rust version for the build.

# Result

After this fix a clean build goes through and after boot the databroker-cli can be tested:
```shell
root@qemuarm64:~# databroker-cli 
transport error
client> help
client commands:

  get             - Get a HAL property
  set             - Set a HAL property
  feed            - Set a HAL property (from vehicle side)
  connect         - Connect
  subscribe       - Subscribe to properties
  metadata        - Get datapoint metadata
  help            - You're looking at it
  quit            - Quit the demo

client> quit
Bye bye!
```