### PR TITLE
Fix data partition not being unmounted properly on power-off

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
@@ -1,0 +1,22 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+#
+# Modifies the original Kanto-CM recipe to use a custom service file that adds a 
+# After=data.mount dependency for CM. This way it is ensured that CM is started AFTER
+# the data partition is properly mounted and the data partition is unmounted AFTER Kanto-CM
+# is fully stopped.
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://service.template \
+          "

--- a/meta-leda-components/recipes-sdv/eclipse-kanto/files/service.template
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/files/service.template
@@ -1,0 +1,14 @@
+[Unit]
+Description=Eclipse Kanto - Container Management
+Documentation=https://eclipse.org/kanto/docs/
+After=network.target containerd.service data.mount
+Requires=network.target containerd.service
+
+[Service]
+Type=simple
+ExecStart=@CM_BIN_DD@/container-management --cfg-file @CM_CFG_DD@/container-management/config.json
+Restart=always
+TimeoutSec=3000
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Issue 

The data.mount service does not wait for the Eclipse Kanto Container Management service to shutdown all running containers properly and thus stop using the mounted /data partition.

This leads to failure to unmount /data on poweroff.

# Fix

Add a .bbapend for the CM recipe that replaces the original service.template with a custom template file that adds to the After= list of the CM-systemd service unit `data.mount` as well.  Systemd stops dependent services in the reverse order of their startup. Thus it waits for container-management.service to stop properly until it stops data.mount.

# Poweroff logs
```shell
root@qemuarm64:~# poweroff
[  OK  ] Removed slice Slice /system/modprobe.
[  OK  ] Stopped target Multi-User System.
[  OK  ] Stopped target Login Prompts.
[  OK  ] Stopped target Host and Network Name Lookups.
[  OK  ] Stopped target Remote File Systems.
[  OK  ] Stopped target System Time Set.
[  OK  ] Stopped target Timer Units.
[  OK  ] Stopped Daily Cleanup of Temporary Directories.
[  OK  ] Closed Load/Save RF Kill Switch Status /dev/rfkill Watch.
         Unmounting /boot...
         Stopping Kernel Logging Service...
         Stopping System Logging Service...
[  OK  ] Stopped SDV cloud connector.
         Stopping Eclipse Kanto - Container Management...
         Stopping GENIVI DLT system. Application to forward syslog messages to DLT, transfer system information, logs and files....
         Stopping GENIVI DLT logging daemon...
         Stopping Eclipse Kanto - File Backup...
         Stopping Eclipse Kanto - File Upload...
         Stopping Getty on tty1...
[  OK  ] Stopped RAUC Good-marking Service.
[  OK  ] Stopped target Boot Completion Check.
         Stopping SDV Self Update Agent...
         Stopping Serial Getty on ttyAMA0...
         Stopping Eclipse Kanto - Software Update...
         Stopping Eclipse Kanto - Suite Connector...
         Stopping Eclipse Kanto - System Metrics...
         Stopping User Login Management...
         Stopping Load/Save Random Seed...
         Stopping HawkBit client for Rauc...
[  OK  ] Stopped OpenSSH Key Generation.
[  OK  ] Stopped Kernel Logging Service.
[  OK  ] Stopped System Logging Service.
[  OK  ] Stopped GENIVI DLT system.… information, logs and files..
[  OK  ] Stopped GENIVI DLT logging daemon.
[  OK  ] Stopped Getty on tty1.
[  OK  ] Stopped SDV Self Update Agent.
[  OK  ] Stopped Serial Getty on ttyAMA0.
[  OK  ] Stopped User Login Management.
[  OK  ] Stopped Eclipse Kanto - File Backup.
[  OK  ] Stopped Eclipse Kanto - File Upload.
[  OK  ] Stopped Eclipse Kanto - Software Update.
[  OK  ] Stopped Eclipse Kanto - Suite Connector.
[  OK  ] Stopped Eclipse Kanto - System Metrics.
[  OK  ] Stopped HawkBit client for Rauc.
[  OK  ] Stopped Eclipse Kanto - Container Management.
[  OK  ] Unmounted /boot.
[  OK  ] Stopped Load/Save Random Seed.
[  OK  ] Removed slice Slice /system/getty.
[  OK  ] Removed slice Slice /system/serial-getty.
[  OK  ] Stopped target Network is Online.
         Unmounting /data...
         Stopping containerd container runtime...
         Stopping Mosquitto MQTT Broker...
         Stopping RAUC Update Service...
[  OK  ] Stopped Wait for Network to be Configured.
[  OK  ] Stopped containerd container runtime.
[  OK  ] Stopped RAUC Update Service.
         Stopping D-Bus System Message Bus...
[  OK  ] Stopped Mosquitto MQTT Broker.
[  OK  ] Stopped target Network.
         Stopping Network Name Resolution...
[  OK  ] Stopped Network Name Resolution.
[  OK  ] Unmounted /data. < ---------------------------------Unmounted properly
[  OK  ] Stopped File System Check on /dev/disk/by-label/data.
[  OK  ] Removed slice Slice /system/systemd-fsck.
         Stopping Network Configuration...
[  OK  ] Stopped D-Bus System Message Bus.
[  OK  ] Stopped Network Configuration.
[  OK  ] Stopped target Preparation for Network.
[  OK  ] Stopped IPv6 Packet Filtering Framework.
[  OK  ] Stopped IPv4 Packet Filtering Framework.
[  OK  ] Stopped target Basic System.
[  OK  ] Stopped target Path Units.
[  OK  ] Stopped Dispatch Password …ts to Console Directory Watch.
[  OK  ] Stopped Forward Password R…uests to Wall Directory Watch.
[  OK  ] Stopped target Slice Units.
[  OK  ] Removed slice User and Session Slice.
[  OK  ] Stopped target Socket Units.
[  OK  ] Closed D-Bus System Message Bus Socket.
[  OK  ] Closed sshd.socket.
[  OK  ] Stopped target System Initialization.
[  OK  ] Closed Syslog Socket.
[  OK  ] Closed Network Service Netlink Socket.
[  OK  ] Stopped Apply Kernel Variables.
[  OK  ] Stopped Load Kernel Modules.
         Stopping Network Time Synchronization...
[  OK  ] Stopped Update is Completed.
[  OK  ] Stopped Rebuild Dynamic Linker Cache.
[  OK  ] Stopped Rebuild Journal Catalog.
         Stopping Record System Boot/Shutdown in UTMP...
[  OK  ] Stopped Record System Boot/Shutdown in UTMP.
[  OK  ] Stopped Network Time Synchronization.
[  OK  ] Stopped Create Volatile Files and Directories.
[  OK  ] Stopped target Local File Systems.
         Unmounting /run/credentials/systemd-sysusers.service...
         Unmounting Temporary Directory /tmp...
         Unmounting /var/volatile...
[  OK  ] Unmounted /run/credentials/systemd-sysusers.service.
[  OK  ] Unmounted Temporary Directory /tmp.
[  OK  ] Unmounted /var/volatile.
[  OK  ] Stopped target Preparation for Local File Systems.
[  OK  ] Stopped target Swaps.
[  OK  ] Reached target Unmount All Filesystems.
[  OK  ] Stopped Create Static Device Nodes in /dev.
[  OK  ] Stopped Create System Users.
[  OK  ] Stopped Remount Root and Kernel File Systems.
[  OK  ] Reached target System Shutdown.
[  OK  ] Reached target Late Shutdown Services.
[  OK  ] Finished System Power Off.
[  OK  ] Reached target System Power Off.
[   43.070633] reboot: Power down
runqemu - INFO - Cleaning up
runqemu - INFO - Host uptime: 5881.41
```
