### PR TITLE
Readded debug package for rust apps

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/files/self-update-agent/self-update-agent.service
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/files/self-update-agent/self-update-agent.service
@@ -22,4 +22,4 @@ WantedBy=multi-user.target
 [Service]
 Restart=on-failure
 RestartSec=30s
-ExecStart=/usr/bin/self-update-agent -p /data/self-update-images --host 127.0.0.1
+ExecStart=/usr/bin/self-update-agent -p /data/selfupdates --host 127.0.0.1

--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
@@ -48,7 +48,7 @@ FILES:${PN} += " \
 "
 
 FILES:${PN}-data += " \
-    /data/self-update-images/ \
+    /data/selfupdates \
 "
 
 FILES:${PN}-dbg += " \
@@ -65,5 +65,5 @@ do_install() {
     install -d ${D}${libdir}
     install -m 755 ${B}/3rdparty/libmini-yaml.so ${D}${libdir}
 
-    install -d ${D}/data/self-update-images/
+    install -d ${D}/data/selfupdates
 }

--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
@@ -37,7 +37,7 @@ DEPENDS += "glib-networking"
 DEPENDS += "nlohmann-json"
 DEPENDS += "paho-mqtt-cpp"
 
-PACKAGES = "${PN}-data ${PN}"
+PACKAGES = "${PN}-data ${PN} ${PN}-dbg"
 
 SYSTEMD_SERVICE:${PN} = "self-update-agent.service"
 
@@ -49,6 +49,10 @@ FILES:${PN} += " \
 
 FILES:${PN}-data += " \
     /data/self-update-images/ \
+"
+
+FILES:${PN}-dbg += " \
+    ${bindir}/.debug/ \
 "
 
 do_install() {


### PR DESCRIPTION
When building non-Leda distros, the recipe needs to define where to put the Rust applications debug binary.