### PR TITLE
Mosquitto config adaption

### DIFF
--- a/meta-leda-distro/recipes-connectivity/mosquitto/files/mosquitto.conf
+++ b/meta-leda-distro/recipes-connectivity/mosquitto/files/mosquitto.conf
@@ -1,0 +1,5 @@
+listener 1883 0.0.0.0
+listener 1883 ::1
+allow_anonymous true
+
+include_dir /etc/mosquitto/conf.d

--- a/meta-leda-distro/recipes-connectivity/mosquitto/mosquitto_%.bbappend
+++ b/meta-leda-distro/recipes-connectivity/mosquitto/mosquitto_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " file://mosquitto.conf"
+
+do_install:append() {
+  install -m 0644 ${WORKDIR}/mosquitto.conf ${D}${sysconfdir}/mosquitto
+  install -d ${D}${sysconfdir}/mosquitto/conf.d
+}


### PR DESCRIPTION
Override the inherited mosquitto config from Kanto to allow local client connections.