### PR TITLE
Patch containerd service unit to be After=data.mount on power on

### DIFF
--- a/meta-leda-distro/recipes-containers/containerd/containerd-opencontainers_%.bbappend
+++ b/meta-leda-distro/recipes-containers/containerd/containerd-opencontainers_%.bbappend
@@ -1,7 +1,9 @@
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://config.toml"
+SRC_URI += "file://config.toml \
+            file://containerd_service_depends_on_data.patch \
+            "
 
 do_install:append() {
     install -d ${D}${sysconfdir}/containerd

--- a/meta-leda-distro/recipes-containers/containerd/files/containerd_service_depends_on_data.patch
+++ b/meta-leda-distro/recipes-containers/containerd/files/containerd_service_depends_on_data.patch
@@ -1,0 +1,12 @@
+index e4c082b3a..d4042d748 100644
+--- a/containerd.service
++++ b/containerd.service
+@@ -15,7 +15,7 @@
+ [Unit]
+ Description=containerd container runtime
+ Documentation=https://containerd.io
+-After=network.target local-fs.target
++After=network.target local-fs.target data.mount
+ 
+ [Service]
+ ExecStartPre=-/sbin/modprobe overlay


### PR DESCRIPTION
# Issue

The kanto-CM service unit being dependent on the `data.mount` provided a partial fix for the issue of improperly un-mounting the /data partition  (most cases when `shutdown now` and `poweroff` were used). 

However, containerd might continue to use /data even after kanto-cm is stopped, leading to improper un-mounting of the partition when the system was rebooted very soon after startup for example.

# Fix

A similar patch for the containerd service unit was provided that makes it depend on the data.mount service on startup (services are stopped in the reverse order on power-off).

# Testing

A qemux86-64 and a qemuarm64 leda-distro builds were tested. The system was shut off quickly after a build, rebooted via `reboot now` and so on. No cases of improper dismount of /data were observed

# Power-off logs

```text
...
[  OK  ] Stopped D-Bus System Message Bus.
[  OK  ] Unmounted /run/containerd/…4216-9e02-fcdbe4ee4606/rootfs.
[  OK  ] Unmounted /run/container-management/netns/c8603ff829db.
[  OK  ] Unmounted /run/containerd/…4d72-8442-317765dcaa4f/rootfs.
[  OK  ] Unmounted /run/container-management/netns/4a65d8d364d7.
[  OK  ] Unmounted /run/containerd/…4d60-86f0-f1a5e3fd946e/rootfs.
[  OK  ] Unmounted /run/container-management/netns/66402b492bfa.
[  OK  ] Unmounted /run/containerd/…4090-b7b8-48c3f0a18d4a/rootfs.
[  OK  ] Unmounted /run/container-management/netns/0859b29be63c.
[  OK  ] Unmounted /run/containerd/…46d6-8b65-5022ad5d176b/rootfs.
[  OK  ] Unmounted /run/container-management/netns/516769aeb6b6.
[  OK  ] Unmounted /run/containerd/…47f8-98d9-597686eb8284/rootfs.
[  OK  ] Unmounted /run/container-management/netns/f9d87dd63917.
[  OK  ] Stopped Eclipse Kanto - Container Management.
         Stopping containerd container runtime...
[  OK  ] Stopped containerd container runtime.
[  OK  ] Stopped target Network.
         Unmounting /data...
         Stopping Network Name Resolution...
[  OK  ] Stopped Network Name Resolution.
[  OK  ] Unmounted /data.
...
```

From the logs it can be observed that the order of services being stopped is:

1) Unmount containerd virtual files at /run/
2) Stop Eclipse kanto-cm service (**takes a long time**)
3) Stop containerd 
4) Unmount /data