### PR TITLE
Disable duplicates for SUA and cloud connector

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
@@ -26,8 +26,8 @@ inherit cargo kanto-auto-deployer
 RDEPENDS_${PN} += " grpc protobuf nativesdk-protobuf"
 DEPENDS += " protobuf protobuf-native grpc git-native"
 
-SRCREV = "467e4cebd86dcfee686b1e676ed0f30ca741354a"
-PV:append = ".AUTOINC+467e4cebd86"
+SRCREV = "9f68b40d7880261ee04450f20ad1e3b59ef5a692"
+PV:append = ".AUTOINC+9f68b40d788"
 SRC_URI = "gitsm://github.com/eclipse-leda/leda-utils;protocol=https;nobranch=0;branch=main"
 
 S = "${WORKDIR}/git"

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-additions.bb
@@ -17,8 +17,6 @@ DESCRIPTION = "Packages required to set up a basic working demo SDV system, but 
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
-    leda-contrib-cloud-connector \
-    leda-contrib-self-update-agent \
     kanto-auto-deployer \
     kantui \
 "

--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-core-direct.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-core-direct.bb
@@ -18,4 +18,7 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     ca-certificates \
+    mosquitto \
+    leda-contrib-cloud-connector \
+    leda-contrib-self-update-agent \
     rauc "


### PR DESCRIPTION
Moving leda-contrib-self-update-agent and leda-contrib-cloud-connector (which are the native versions) to the rescue partition.

Right now, SUA and cloudconnector are deployed as containers on the main image (sdv-image-full) and if we also install them natively, there is a conflict. Esp. cloudconnector behaves strange if there are multiple instances running on the same device (as they're both using the same MQTT Client Id)

By moving the native versions to the rescue partition, we can still test them on the rescue partition and keep the containerized versions on the full and minimal images.