### PR TITLE
Fix rauc slot switching in QEMUARM64

### DIFF
--- a/meta-leda-bsp/recipes-bsp/uboot/files/qemuarm64/boot.cmd.in
+++ b/meta-leda-bsp/recipes-bsp/uboot/files/qemuarm64/boot.cmd.in
@@ -1,5 +1,5 @@
+if test -e virtio 0:1 uboot.env; then env load; fi;
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
-
 test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "SDV_A SDV_B"
 test -n "${BOOT_SDV_A_LEFT}" || setenv BOOT_SDV_A_LEFT 3
 test -n "${BOOT_SDV_B_LEFT}" || setenv BOOT_SDV_B_LEFT 3

--- a/meta-leda-bsp/recipes-bsp/uboot/files/qemuarm64/env_in_fat_qemuarm.patch
+++ b/meta-leda-bsp/recipes-bsp/uboot/files/qemuarm64/env_in_fat_qemuarm.patch
@@ -2,7 +2,7 @@ diff --git a/configs/qemu_arm64_defconfig b/configs/qemu_arm64_defconfig
 index e8a6f752cd..82cfec1b29 100644
 --- a/configs/qemu_arm64_defconfig
 +++ b/configs/qemu_arm64_defconfig
-@@ -26,7 +26,9 @@ CONFIG_CMD_USB=y
+@@ -26,7 +26,11 @@ CONFIG_CMD_USB=y
  CONFIG_CMD_TPM=y
  CONFIG_CMD_MTDPARTS=y
  CONFIG_OF_BOARD=y
@@ -10,6 +10,8 @@ index e8a6f752cd..82cfec1b29 100644
 +CONFIG_ENV_IS_IN_FAT=y
 +CONFIG_ENV_FAT_INTERFACE="virtio"
 +CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
++CONFIG_CMD_NVEDIT_LOAD=y
++CONFIG_CMD_FAT=y
  CONFIG_ENV_ADDR=0x4000000
  CONFIG_SCSI_AHCI=y
  CONFIG_AHCI_PCI=y


### PR DESCRIPTION
# Issue 

Uboot would save the environment in uboot.env but it would not read it back on the next boot. This leads to rauc being able to mark the slots good but would `rauc status mark-active other && reboot now` would switch the rauc-slot.

# Fix

Add the `CONFIG_CMD_NVEDIT_LOAD=y` option to the uboot Kconfig. This allows us to use the `env load` command in the boot.scr, thus successfully loading the saved/modified uboot env.
