### PR TITLE
Fix raspberry pi rauc "other" slot being marked "bad"

### DIFF
--- a/meta-leda-components/dynamic-layers/raspberry-pi/files/boot.cmd.in
+++ b/meta-leda-components/dynamic-layers/raspberry-pi/files/boot.cmd.in
@@ -20,8 +20,8 @@
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 
 test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "SDV_A SDV_B"
-test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
-test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
+test -n "${BOOT_SDV_A_LEFT}" || setenv BOOT_SDV_A_LEFT 3
+test -n "${BOOT_SDV_B_LEFT}" || setenv BOOT_SDV_B_LEFT 3
 test -n "${BOOT_DEV}" || setenv BOOT_DEV "mmc 0:3"
 
 setenv bootpart
@@ -31,16 +31,16 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   if test "x${bootpart}" != "x"; then
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xSDV_A"; then
-    if test ${BOOT_A_LEFT} -gt 0; then
-      setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
+    if test ${BOOT_SDV_A_LEFT} -gt 0; then
+      setexpr BOOT_SDV_A_LEFT ${BOOT_SDV_A_LEFT} - 1
       echo "Found valid RAUC slot SDV_A"
       setenv bootpart "/dev/mmcblk0p4"
       setenv raucslot "SDV_A"
       setenv BOOT_DEV "mmc 0:4"
     fi
   elif test "x${BOOT_SLOT}" = "xSDV_B"; then
-    if test ${BOOT_B_LEFT} -gt 0; then
-      setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
+    if test ${BOOT_SDV_B_LEFT} -gt 0; then
+      setexpr BOOT_SDV_B_LEFT ${BOOT_SDV_B_LEFT} - 1
       echo "Found valid RAUC slot SDV_B"
       setenv bootpart "/dev/mmcblk0p5"
       setenv raucslot "SDV_B"
@@ -54,8 +54,8 @@ if test -n "${bootpart}"; then
   saveenv
 else
   echo "No valid RAUC slot found. Resetting tries to 3"
-  setenv BOOT_A_LEFT 3
-  setenv BOOT_B_LEFT 3
+  setenv BOOT_SDV_A_LEFT 3
+  setenv BOOT_SDV_B_LEFT 3
   saveenv
   reset
 fi


### PR DESCRIPTION
# Issue 

On the rpi4-64 the "other" slot (SDV_B) gets marked bad. This is because the rauc-mark-good service manages the variables BOOT_<SLOT>_LEFT but the names of the slots in the script were inconsistent. (Rauc was tracking SDV_A, but the "counter" variable was BOOT_A_LEFT" for example.

# Fix

Make variable naming consistent. Now, on first boot (and all subsequent boots), both slots are marked "good":

![image](https://user-images.githubusercontent.com/59696861/214565931-be4fdaac-34af-44bb-8782-2bf0420c1052.png)
