### PR TITLE
Extend partitions for RAUC

### DIFF
--- a/meta-leda-distro/wic/qemuarm64.wks
+++ b/meta-leda-distro/wic/qemuarm64.wks
@@ -33,6 +33,6 @@ part --fixed-size 10M --ondisk vda --align 4096 --no-table
 # Empty partition (on x86, this is grubenv - we store RAUC Status here as well)
 part --fixed-size 10M --ondisk vda --align 4096
 part --source rootfs --rootfs-dir=sdv-image-rescue --ondisk vda --fstype=ext4 --label rescue --align 1024
-part --source rootfs --rootfs-dir=sdv-image-full --ondisk vda --fstype=ext4 --label root_a --align 4096
-part --source rootfs --rootfs-dir=sdv-image-minimal  --ondisk vda --fstype=ext4 --label root_b --align 4096
-part --fixed-size 2048M --source rootfs --rootfs-dir=sdv-image-data --ondisk vda --fstype=ext4 --label data --align 4096
+part --extra-space 50M --source rootfs --rootfs-dir=sdv-image-full --ondisk vda --fstype=ext4 --label root_a --align 4096
+part --extra-space 50M --source rootfs --rootfs-dir=sdv-image-minimal  --ondisk vda --fstype=ext4 --label root_b --align 4096
+part --fixed-size 3072M --source rootfs --rootfs-dir=sdv-image-data --ondisk vda --fstype=ext4 --label data --align 4096

--- a/meta-leda-distro/wic/qemux86-grub-efi.wks
+++ b/meta-leda-distro/wic/qemux86-grub-efi.wks
@@ -37,11 +37,11 @@ part --source rootfs --rootfs-dir=sdv-image-rescue --ondisk vda --fstype=ext4 --
 
 # First Root Partition (active, pre-installed), mounted readonly to show that root fs can be readonly
 # and all container-apps in cluster are contained on /data
-part --source rootfs --rootfs-dir=sdv-image-full --ondisk vda --fstype=ext4 --label root_a
+part --extra-space 50M --source rootfs --rootfs-dir=sdv-image-full --ondisk vda --fstype=ext4 --label root_a
 
 # Second Root Partition (empty, not mounted) to show the self-update mechanism
-part --source rootfs --rootfs-dir=sdv-image-minimal --ondisk vda --fstype=ext4 --label root_b
+part --extra-space 50M --source rootfs --rootfs-dir=sdv-image-minimal --ondisk vda --fstype=ext4 --label root_b
 
 # The data partition to store Kanto Container Management state (e.g. containerized apps)
 # Last partition, so that it can be grown (eg on Raspi to full SD-Card capacitiy, on qemu by extending the qcow2 disk image file)
-part --fixed-size 2048M --source rootfs --rootfs-dir=sdv-image-data --ondisk vda --fstype=ext4 --label data
+part --fixed-size 3072M --source rootfs --rootfs-dir=sdv-image-data --ondisk vda --fstype=ext4 --label data


### PR DESCRIPTION
The partitions (rootfs.0 and rootfs.1 slots of RAUC) are extended by 50M to allow installing RAUC Update Bundles.