### PR TITLE
meta-kanto layer added to rpi4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ build/
 meta-kanto
 meta-openembedded
 meta-rauc
-meta-kanto
 meta-rauc-community
 meta-virtualization
 meta-raspberrypi

--- a/kas/.config-kirkstone-rpi4.yaml
+++ b/kas/.config-kirkstone-rpi4.yaml
@@ -54,6 +54,9 @@ repos:
   meta-rauc:
     url: "https://github.com/rauc/meta-rauc.git"
     refspec: kirkstone
+  meta-kanto:
+    url: "https://github.com/eclipse-kanto/meta-kanto.git"
+    refspec: kirkstone
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     refspec: kirkstone


### PR DESCRIPTION
Added to .config-kirkstone-rpi4.yaml:

>   meta-kanto:
>       url: "https://github.com/eclipse-kanto/meta-kanto.git"
>       refspec: kirkstone
> 

Removed duplicated meta-kanto from .gitignore
