### PR TITLE
virtio only for qemu

### DIFF
--- a/meta-leda-distro/recipes-kernel/linux/sdv-qemu-virtio.inc
+++ b/meta-leda-distro/recipes-kernel/linux/sdv-qemu-virtio.inc
@@ -15,7 +15,9 @@ SUMMARY = "SDV QEMU Virtual Device Support"
 DESCRIPTION = "Enables support for QEMU emulated devices"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-yocto:"
-SRC_URI:append = " file://qemu-virtio.cfg"
+SRC_URI:append:qemuarm = " file://qemu-virtio.cfg"
+SRC_URI:append:qemuarm64 = " file://qemu-virtio.cfg"
+SRC_URI:append:qemux86-64 = " file://qemu-virtio.cfg"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"


### PR DESCRIPTION
virtio interface is only available for:

- qemuarm
- qemuarm64
- qemux86-64 