### PR TITLE
Remove leda-distro dependency on leda-bsp

### DIFF
--- a/meta-leda-distro/conf/layer.conf
+++ b/meta-leda-distro/conf/layer.conf
@@ -21,5 +21,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-leda-distro"
 BBFILE_PATTERN_meta-leda-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-leda-distro = "7"
-LAYERDEPENDS_meta-leda-distro += "meta-leda-bsp meta-leda-components"
+LAYERDEPENDS_meta-leda-distro += "meta-leda-components"
 LAYERSERIES_COMPAT_meta-leda-distro = "kirkstone"


### PR DESCRIPTION
# Changes

The meta-leda-distro layer no longer depends on meta-leda-bsp. This allows the meta-leda-distro layer to be reused without having to include the QEMU/rpi64 bsp-recipes as well.

# Tests

Tested for:

- QEMUx86-64
- RPI64
- QEMUARM64

All of these targets still build successfully. Running sdv-health and rauc status show that the system is running as expected (qemux86-64 screenshots only for brevity):

![qemux86-rauc](https://user-images.githubusercontent.com/59696861/218731149-0038ac80-a2ee-4c61-b66c-9f84ff90e0d9.png)

![qemux86-sdv-health](https://user-images.githubusercontent.com/59696861/218731153-432daf07-de1a-4a09-83fd-f255a7a8f9a7.png)

