### PR TITLE
Setup poky core-image-minimal + sdv-core image kas config

### DIFF
--- a/.github/workflows/poky-sdv-core.yml
+++ b/.github/workflows/poky-sdv-core.yml
@@ -1,0 +1,51 @@
+name: Build Poky with SDV Core
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+
+  poky-core-qemux86_64:
+    name: "poky-minimal-sdv-core-qemux86_64"
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+    
+    - name: Checkout
+      uses: actions/checkout@v3
+    
+    - name: Install tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq libvirt-clients libvirt-daemon-system qemu-system-x86 qemu-system-arm qemu-kvm squashfs-tools rauc python3-newt ca-certificates curl gnupg lsb-release
+    
+    - name: Install kas
+      run: sudo pip3 install kas
+
+    - name: Build poky-core-image-minimal + sdv-core
+      env:
+        KAS_MACHINE: qemux86-64
+      run: |
+        (r=3;while ! kas build kas/poky-sdv-qemux86-64.yaml; do ((--r))||exit;sleep 60;done)
+
+    - name: Package all files
+      run: |
+        export ARC=poky-minimal-sdv-core-qemu-x86_64.tar
+        rm -f ${ARC}.xz
+        time tar --append --verbose --dereference --file ${ARC} -C ./build/tmp/deploy/images/qemux86-64/ \
+          bzImage-qemux86-64.bin \
+          core-image-minimal-qemux86-64.ext4 \
+          core-image-minimal-qemux86-64.manifest \
+          core-image-minimal-qemux86-64.qemuboot.conf \
+          core-image-minimal-qemux86-64.tar.bz2 \
+          core-image-minimal-qemux86-64.testdata.json \
+          modules-qemux86-64.tgz
+        time xz -v -8 -T0 ${ARC}
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with: 
+        name: poky-minimal-sdv-core-qemu-x86_64.tar.xz
+        if-no-files-found: error
+        path: poky-minimal-sdv-core-qemu-x86_64.tar.xz

--- a/kas/poky-sdv-qemux86-64.yaml
+++ b/kas/poky-sdv-qemux86-64.yaml
@@ -1,0 +1,27 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# Every file needs to contain a header, that provides kas with information
+# about the context of this file.
+header:
+  version: 12
+  includes:
+  - .config-components.yaml
+  - mirrors.yaml
+distro: poky
+target: core-image-minimal
+local_conf_header:
+  user: |
+    IMAGE_INSTALL:append = " packagegroup-sdv-core"
+    DISTRO_FEATURES += " sdv rauc virtualization"
+    EXTRA_IMAGE_FEATURES += "debug-tweaks"
+machine: qemux86-64


### PR DESCRIPTION
# Kas-config

1. Directly include .config-components as a base (this would lead to all package groups being built, but only core is included in the image, e.g. no kantui)
2. IMAGE_INSTALL `packagegroup-sdv-core`
3. Set distro as poky and target as core-image minimal
4. Use qemux86-64 as initial target machine
 
# Results:
- Successful build
- Successful boot
- Container management, kanto-cm available (No systemd unit, not autostarted, socket not created)
- Containerd, runc available (no systemd unit)
- kanto-auto-deployer available
- ssh, sshd available. sshd working (you can ssh into the image with `ssh -p 2222 root@127.0.0.1`)
- leda bash utils available but mostly broken (sdv-motd can't bind to kanto-cm socket, sdv-health fails on `/etc/os-release` not being available (running `touch /etc/os-release` lets it proceed however)
- rauc available, but not working:
```shell
root@qemux86-64:~# rauc status
Error retrieving slot status via D-Bus: error creating proxy: Error calling StartServiceByName for de.pengutronix.rauc: Launch helper exited with unknown return code 1
```

- mosquitto installed and running as service on localhost

## Leda utils output

```shell
root@qemux86-64:/opt/containerd/bin# sdv-motd
 _          _       
| | ___  __| | __ _ 
| |/ _ \/ _` |/ _` |
| |  __/ (_| | (_| |
|_|\___|\__,_|\__,_|
Poky (Yocto Project Reference Distro) 4.0.7 \n \l (GNU/Linux 5.15.87-yocto-standard x86_64)
ip: can't find device 'eth0 '

 Hostname......: qemux86-64
 Uptime........: 0 days, 0:3 hours
 Ø System load.: 0.08 (1min)    | 0.07 (5min)   | 0.02 (15min)
 Disk Space....: Root: 304.9M   | Used: 251.8M  | Free: 32.3M
                 Data:          | Used:         | Free: 
 RAM ..........: Total: 223.9M  | Used: 81.0M   | Free: 16.3M
 Network.......: Interface : eth0 
                 IP Address: 
 Containers....: 0 running      | 0 stopped     | 0 exited

To check SDV services health, run $ sdv-health
Use $ sdv-device-info to display device configuration
Use $ sdv-provision to generate self-signed device certificates

/usr/bin/sdv-motd: line 99: systemctl: not found
Warning:  Container Management is not yet up and running.
root@qemux86-64:~# sdv-health
[SDV Info]
  * OS Release:             : 
  * Image Version:          : Poky (Yocto Project Reference Distro) 4.0.7 \n \l
  * Build Time:             : 20180309123456
-----------------------------------------------------------
[CAN Status]
  * can0                    : FAILED!    (can0 not found)
-----------------------------------------------------------
[SDV Ports]
  * OpenSSH                 : FAILED!    Port 22 not open!
  * Kanto CM                : FAILED!    Socket /run/container-management/container-management.sock not open!
  * Mosquitto Server        : FAILED!    Port 1883 not open!
-----------------------------------------------------------
[SDV Services]
  * containerd              : FAILED!    (/usr/bin/sdv-health: line 97: systemctl: not found)
  * rauc                    : FAILED!    (/usr/bin/sdv-health: line 97: systemctl: not found)
  * container-management    : FAILED!    (/usr/bin/sdv-health: line 97: systemctl: not found)
[SDV Optional Services]
  * sshd.socket             : N/A        (/usr/bin/sdv-health: line 97: systemctl: not found)
  * systemd-networkd        : N/A        (/usr/bin/sdv-health: line 97: systemctl: not found)
  * systemd-timesyncd       : N/A        (/usr/bin/sdv-health: line 97: systemctl: not found)
/usr/bin/sdv-health: line 428: systemctl: not found
-----------------------------------------------------------
[Kanto CM Containers]
  * Kanto Container Management               : FAILED! (Unavailable)
-----------------------------------------------------------
[Kanto CM Containers (OPTIONAL)]
  * Kanto Container Management               : FAILED! (Unavailable)
-----------------------------------------------------------
[SDV Connectivity]
  * Ping [Internet]         : FAILED!    (error: 1)      (ping 1.1.1.1)
/usr/bin/sdv-health: line 446: resolvectl: not found
  * DNS Lookup [Internet]   : OK         ()
/usr/bin/sdv-health: line 203: mosquitto_sub: not found
  * Cloud Connector         : FAILED!
/usr/bin/sdv-health: line 227: mosquitto_rr: not found
  * Device ID:              : FAILED!    (127)
-----------------------------------------------------------
```