### PR TITLE
Rauc verity bundles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,6 +42,11 @@ RUN sudo apt-get -y install software-properties-common \
     && sudo apt-get -y update \
     && sudo apt-get -y install libfuse3-dev fuse3 blobfuse2
 
+# Update RAUC to 1.8.1 from Debian Testing channel
+RUN sudo apt-add-repository 'deb http://deb.debian.org/debian/ testing main' \
+    && sudo apt-get -y update \
+    && sudo apt-get -y install -t testing rauc
+
 # Try to enable KVM to improve performance of qemu-system-x86 on x86 hosts.
 # This is also run in post-attach.sh
 RUN /bin/bash -c "(groupadd --system kvm; gpasswd -a vscode kvm; chown root:kvm /dev/kvm; chmod 0660 /dev/kvm; echo 'KVM permissions set up') || true"

--- a/meta-leda-bsp/conf/machine/raspberrypi4-64-extra.conf
+++ b/meta-leda-bsp/conf/machine/raspberrypi4-64-extra.conf
@@ -10,7 +10,7 @@ IMAGE_FSTYPES = "tar.bz2 ext4"
 
 # Allow the root partition to grow to the size of the SD Card on the Raspi
 IMAGE_INSTALL:append = " e2fsprogs-resize2fs"
-IMAGE_INSTALL:append = " parted gptfdisk"
+IMAGE_INSTALL:append = " gptfdisk"
 IMAGE_INSTALL:append = " sdv-raspberry-growdisk"
 
 # Enable single-chip CAN extension based on MCP251x

--- a/meta-leda-bsp/dynamic-layers/raspberry-pi/files/leda-bsp-rauc.cfg
+++ b/meta-leda-bsp/dynamic-layers/raspberry-pi/files/leda-bsp-rauc.cfg
@@ -1,0 +1,27 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+# network block device
+CONFIG_BLK_DEV_NBD=y
+
+# device manager
+CONFIG_BLK_DEV_DM=y
+
+# Format for Rauc
+CONFIG_DM_VERITY=y
+
+# SHA256
+CONFIG_CRYPTO_SHA256=y
+
+# Optimization for Raspberry Pi
+CONFIG_CRYPTO_SHA256_ARM64=y

--- a/meta-leda-bsp/dynamic-layers/raspberry-pi/linux-raspberrypi_%.bbappend
+++ b/meta-leda-bsp/dynamic-layers/raspberry-pi/linux-raspberrypi_%.bbappend
@@ -1,0 +1,18 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+inherit rauc-integration
+
+SRC_URI:append:rauc-integration = " file://leda-bsp-rauc.cfg"

--- a/meta-leda-bsp/recipes-bsp/rauc/files/qemuarm64/system.conf
+++ b/meta-leda-bsp/recipes-bsp/rauc/files/qemuarm64/system.conf
@@ -29,6 +29,7 @@
 compatible=Eclipse Leda (qemuarm64)
 bootloader=uboot
 statusfile=/data/rauc.status
+data-directory=/data/rauc
 
 [keyring]
 path=ca.cert.pem
@@ -42,7 +43,6 @@ region-size=100M
 [slot.rescue.0]
 device=/dev/vda3
 type=ext4
-readonly=true
 
 [slot.rootfs.0]
 device=/dev/vda4

--- a/meta-leda-bsp/recipes-bsp/rauc/files/qemux86-64/system.conf
+++ b/meta-leda-bsp/recipes-bsp/rauc/files/qemux86-64/system.conf
@@ -29,6 +29,7 @@
 compatible=Eclipse Leda (qemux86-64)
 bootloader=uboot
 statusfile=/data/rauc.status
+data-directory=/data/rauc
 
 [keyring]
 path=ca.cert.pem
@@ -42,7 +43,6 @@ region-size=100M
 [slot.rescue.0]
 device=/dev/vda3
 type=ext4
-readonly=true
 
 [slot.rootfs.0]
 device=/dev/vda4

--- a/meta-leda-bsp/recipes-bsp/rauc/files/raspberrypi4-64/system.conf
+++ b/meta-leda-bsp/recipes-bsp/rauc/files/raspberrypi4-64/system.conf
@@ -29,9 +29,14 @@
 compatible=Eclipse Leda (raspberrypi4-64)
 bootloader=uboot
 statusfile=/data/rauc.status
+data-directory=/data/rauc
 
 [keyring]
 path=ca.cert.pem
+
+[slot.rescue.0]
+device=/dev/mmcblk0p3
+type=ext4
 
 [slot.rootfs.0]
 device=/dev/mmcblk0p4

--- a/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-full.bb
+++ b/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-full.bb
@@ -1,0 +1,21 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+require sdv-rauc-bundle.inc
+
+RAUC_BUNDLE_SLOTS = "rootfs"
+RAUC_SLOT_rootfs = "sdv-image-full"
+RAUC_SLOT_rootfs[fstype] = "ext4"
+
+# Using block hash index improves performance of install
+RAUC_SLOT_rootfs[adaptive] = "block-hash-index"

--- a/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-minimal.bb
+++ b/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-minimal.bb
@@ -1,0 +1,21 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+require sdv-rauc-bundle.inc
+
+RAUC_BUNDLE_SLOTS = "rootfs"
+RAUC_SLOT_rootfs = "sdv-image-minimal"
+RAUC_SLOT_rootfs[fstype] = "ext4"
+
+# Using block hash index improves performance of install
+RAUC_SLOT_rootfs[adaptive] = "block-hash-index"

--- a/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-rescue.bb
+++ b/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-rescue.bb
@@ -19,4 +19,3 @@ RAUC_SLOT_rescue[fstype] = "ext4"
 
 # Using block hash index improves performance of install
 RAUC_SLOT_rescue[adaptive] = "block-hash-index"
-

--- a/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-rescue.bb
+++ b/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle-rescue.bb
@@ -1,0 +1,22 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+require sdv-rauc-bundle.inc
+
+RAUC_BUNDLE_SLOTS = "rescue"
+RAUC_SLOT_rescue = "sdv-image-rescue"
+RAUC_SLOT_rescue[fstype] = "ext4"
+
+# Using block hash index improves performance of install
+RAUC_SLOT_rescue[adaptive] = "block-hash-index"
+

--- a/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle.inc
+++ b/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle.inc
@@ -16,39 +16,21 @@ inherit bundle
 # Must match to RAUCs system.conf files
 RAUC_BUNDLE_COMPATIBLE = "Eclipse Leda (${MACHINE})"
 
+# Use the newer Verity format for streaming update bundles
 RAUC_BUNDLE_FORMAT = "verity"
 
-# To build multiple/different slots, add them here and then add RAUC_SLOT_slotname to map to BitBake images
-# RAUC_BUNDLE_SLOTS = "rootfs_full rootfs_minimal"
-# RAUC_SLOT_rootfs_full = "sdv-image-full"
-# RAUC_SLOT_rootfs_minimal = "sdv-image-minimal"
-
-# For now, we only have one "rootfs" slot and it will always be a "sdv-image-minimal" to save download size.
-RAUC_BUNDLE_SLOTS = "rootfs"
-
-# The name of the image to use, this could later be "sdv-core-image-minimal"
-RAUC_SLOT_rootfs = "sdv-image-minimal"
-
-# Override the rootfs fstype for rauc, otherwise rauc will bundle "wic.qcow2" file,
-# which cannot be used from within the guest. RAUC would fail on installing a "wic.qcow2" file.
-RAUC_SLOT_rootfs[fstype] = "ext4"
-
-# These are set in site.conf
+# These are set in site.conf or in kas yaml files
 # RAUC_KEY_FILE = "${THISDIR}/path/to/development-1.key.pem"
 # RAUC_CERT_FILE = "${THISDIR}/path/to/development-1.cert.pem"
 
 # Set RAUC bundle version to git tag or git commit in case no tag is available
-def exec_git_run(cmd, path):
-    (output, error) = bb.process.run(cmd, cwd=path)
-    return output.rstrip()
-
 def get_imageversion(d):
     # Default fallback is just the version of the distro ("2022")
     layerRev = d.getVar("DISTRO_VERSION")
     path = d.getVar("TOPDIR") or d.getVar("BUILD_DIR")
     try:
-        ver = exec_git_run("git describe --always --tags", path)
-        layerRev = ver
+        (output, error) = bb.process.run("git describe --always --tags", path)
+        layerRev = output.rstrip()
     except Exception as exc:
         bb.warn('Exception executing git, falling back to DISTRO_VERSION')
     d.setVar("VERSION_ID", layerRev)

--- a/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle.inc
+++ b/meta-leda-components/recipes-sdv/sdv-core/sdv-rauc-bundle.inc
@@ -29,10 +29,10 @@ def get_imageversion(d):
     layerRev = d.getVar("DISTRO_VERSION")
     path = d.getVar("TOPDIR") or d.getVar("BUILD_DIR")
     try:
-        (output, error) = bb.process.run("git describe --always --tags", path)
+        (output, error) = bb.process.run("git describe --always --tags", cwd=path)
         layerRev = output.rstrip()
     except Exception as exc:
-        bb.warn('Exception executing git, falling back to DISTRO_VERSION')
+        bb.warn('Exception executing git, falling back to DISTRO_VERSION ${DISTRO_VERSION}', exc)
     d.setVar("VERSION_ID", layerRev)
     return layerRev
 

--- a/meta-leda-distro/conf/distro/leda.conf
+++ b/meta-leda-distro/conf/distro/leda.conf
@@ -41,7 +41,11 @@ RM_WORK_EXCLUDE += " sdv-image-full"
 RM_WORK_EXCLUDE += " sdv-image-minimal"
 RM_WORK_EXCLUDE += " sdv-image-rescue"
 RM_WORK_EXCLUDE += " sdv-image-data"
-RM_WORK_EXCLUDE += " sdv-image-all"
-RM_WORK_EXCLUDE += " sdv-rauc-bundle"
+
+# Reenable for debugging purposes
+# RM_WORK_EXCLUDE += " sdv-image-all"
+# RM_WORK_EXCLUDE += " sdv-rauc-bundle-full"
+# RM_WORK_EXCLUDE += " sdv-rauc-bundle-minimal"
+# RM_WORK_EXCLUDE += " sdv-rauc-bundle-rescue"
 
 QB_KERNEL_CMDLINE_APPEND = "net.ifnames=0 panic=5 ip=dhcp ip=192.168.7.2::192.168.7.1:255.255.255.0::eth0:off rootwait"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-all.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-all.bb
@@ -20,8 +20,25 @@ IMAGE_FEATURES:append = " allow-empty-password"
 IMAGE_FEATURES:append = " empty-root-password"
 
 # The image dependencies are actually both types: build-time and run-time dependency
-RDEPENDS:${PN} = "sdv-image-full sdv-image-minimal sdv-image-rescue sdv-image-data sdv-rauc-bundle"
-DEPENDS = "sdv-image-full sdv-image-minimal sdv-image-rescue sdv-image-data sdv-rauc-bundle"
+RDEPENDS:${PN} = " \
+    sdv-image-full \
+    sdv-image-minimal \
+    sdv-image-rescue \
+    sdv-image-data \
+    sdv-rauc-bundle-full \
+    sdv-rauc-bundle-minimal \
+    sdv-rauc-bundle-rescue \
+    "
+
+DEPENDS = " \
+    sdv-image-full \
+    sdv-image-minimal \
+    sdv-image-rescue \
+    sdv-image-data \
+    sdv-rauc-bundle-full \
+    sdv-rauc-bundle-minimal \
+    sdv-rauc-bundle-rescue \
+    "
 
 WKS_FILE_DEPENDS_BOOTLOADERS:remove = "grub-efi"
 

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
@@ -40,6 +40,12 @@ inherit core-image
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "", d)}"
 
+# Optimizations for RAUC adaptive method 'block-hash-index'
+# rootfs image size must to be 4K-aligned
+IMAGE_ROOTFS_ALIGNMENT = "4"
+# ext4 block and inode size should be set to 4K
+EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"
+
 # Fall back to ext4 for now, as wic for qemuarm does not yet contain u-boot
 #QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"
 QB_FSINFO = "wic:no-kernel-in-fs"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-minimal.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-minimal.bb
@@ -34,6 +34,12 @@ inherit core-image
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "", d)}"
 
+# Optimizations for RAUC adaptive method 'block-hash-index'
+# rootfs image size must to be 4K-aligned
+IMAGE_ROOTFS_ALIGNMENT = "4"
+# ext4 block and inode size should be set to 4K
+EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"
+
 QB_FSINFO = "wic:no-kernel-in-fs"
 
 QB_KERNEL_ROOT = "/dev/vda"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-rescue.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-rescue.bb
@@ -35,6 +35,12 @@ inherit core-image
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "", d)}"
 
+# Optimizations for RAUC adaptive method 'block-hash-index'
+# rootfs image size must to be 4K-aligned
+IMAGE_ROOTFS_ALIGNMENT = "4"
+# ext4 block and inode size should be set to 4K
+EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"
+
 QB_FSINFO = "wic:no-kernel-in-fs"
 
 QB_KERNEL_ROOT = "/dev/vda"


### PR DESCRIPTION
Enable multiple RAUC Update Bundles for each of the rootfs images:
- SDV-Image-Full
- SDV-Image-Minimal
- SDV-Image-Rescue

Also enables the use of RAUC's block-hash-index, which allows optimized performance for the installation process.
