### PR TITLE
Update seatservice example and databroker

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core/databroker.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core/databroker.json
@@ -2,7 +2,7 @@
     "container_id": "databroker",
     "container_name": "databroker",
     "image": {
-        "name": "ghcr.io/eclipse/kuksa.val/databroker:0.3"
+        "name": "ghcr.io/eclipse/kuksa.val/databroker:0.3.0"
     },
     "host_config": {
         "devices": [],

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example_dev/seatservice.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example_dev/seatservice.json
@@ -2,7 +2,7 @@
     "id": "seatservice-example",
     "name": "seatservice-example",
     "image": {
-        "name": "ghcr.io/eclipse/kuksa.val.services/seat_service:v0.1.0",
+        "name": "ghcr.io/boschglobal/kuksa.val.services/seat_service:v0.3.0",
         "decrypt_config": null
     },
     "host_name": "",
@@ -58,7 +58,6 @@
     },
     "config": {
         "env": [
-           "VEHICLEDATABROKER_DAPR_APP_ID=databroker",
            "BROKER_ADDR=databroker-host:30555",
            "RUST_LOG=info",
            "vehicle_data_broker=info"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
@@ -32,6 +32,7 @@ do_install() {
     install -m 0755 ${WORKDIR}/git/src/sh/sdv-health ${D}${bindir}
     install -m 0755 ${WORKDIR}/git/src/sh/sdv-motd ${D}${bindir}
     install -m 0755 ${WORKDIR}/git/src/sh/sdv-provision ${D}${bindir}
+    install -m 0755 ${WORKDIR}/git/src/sh/sdv-ctr-exec ${D}${bindir}
     install -m 0644 ${WORKDIR}/git/src/sh/sdv.conf ${D}/etc/sdv/
 
     install -d ${D}${sysconfdir}/profile.d
@@ -43,6 +44,7 @@ FILES_${PN} += "${bindir}/sdv-device-info"
 FILES_${PN} += "${bindir}/sdv-health"
 FILES_${PN} += "${bindir}/sdv-motd"
 FILES_${PN} += "${bindir}/sdv-provision"
+FILES_${PN} += "${bindir}/sdv-ctr-exec"
 FILES_${PN} += "/etc/sdv/sdv.conf"
 
 PACKAGES = "${PN}"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
@@ -15,7 +15,7 @@ SUMMARY = "SDV Core Utilities"
 DESCRIPTION = "Core shell scripts for Eclipse Leda"
 
 SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
-SRCREV = "d6c104269ca40ac67c863102c29c0cd06cecd472"
+SRCREV = "3f79a1abb1584501872f8d259f8d358c5e5919fd"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
@@ -18,14 +18,21 @@ SRC_URI += "file://LICENSE"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/kanto-containers:"
+SRC_URI:append = " file://core/databroker.json"
+SRC_URI:append = " file://core/vum.json"
+SRC_URI:append = " file://core/sua.json"
+SRC_URI:append = " file://core_dev/cloudconnector.json"
+
+
 do_install:append() {
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${THISDIR}/kanto-containers/core/databroker.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${THISDIR}/kanto-containers/core/vum.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${THISDIR}/kanto-containers/core/sua.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/databroker.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/vum.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/sua.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${THISDIR}/kanto-containers/core_dev/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/core_dev/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 }
 
 PACKAGES = "${PN}"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
@@ -18,18 +18,23 @@ SRC_URI += "file://LICENSE"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/kanto-containers:"
+SRC_URI:append = " file://example/hvac.json"
+SRC_URI:append = " file://example/feedercan.json"
+SRC_URI:append = " file://example_dev/seatservice.json"
+
 do_install:append() {
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${THISDIR}/kanto-containers/example/hvac.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${THISDIR}/kanto-containers/example/feedercan.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/example/hvac.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/example/feedercan.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 # Under construction
-#   install ${THISDIR}/kanto-containers/example/zipkin.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+#   install ${WORKDIR}/example/zipkin.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${THISDIR}/kanto-containers/example_dev/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/example_dev/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 # Under construction
-#    install ${THISDIR}/kanto-containers/example_dev/otelcol-sdv-agent.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-#    install ${THISDIR}/kanto-containers/example_dev/otelcol-sdv-exporter.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+#    install ${WORKDIR}/example_dev/otelcol-sdv-agent.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+#    install ${WORKDIR}/example_dev/otelcol-sdv-exporter.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 
 }
 


### PR DESCRIPTION
- Update seatservice and databroker
- Add sdv-ctr-exec

To update seatservice to work on host networking with physical can, you can apply the patch:
(To be documented in end-user-docs)

[seatservice.txt](https://github.com/eclipse-leda/meta-leda/files/10896958/seatservice.txt)


In simulated can mode you can run:
```shell
$ sdv-ctr-exec -n seatservice-example /app/bin/seat_svc_client [0..1000]
```
to mock-move the seat.
