### PR TITLE
Add wpa_supplicant.conf if exists in boot

### DIFF
--- a/meta-leda-components/recipes-sdv/sdv-wifi/files/wpa.service
+++ b/meta-leda-components/recipes-sdv/sdv-wifi/files/wpa.service
@@ -12,9 +12,9 @@
 # ********************************************************************************/
 # 
 [Unit]
-Description=wpa_supplicant start service
-After=network-online.target
-Wants=network-online.target
+Description=Start wpa_supplicant
+After=network-online.target boot.mount root.mount
+Wants=network-online.target boot.mount root.mount
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-leda-components/recipes-sdv/sdv-wifi/files/wpa.sh
+++ b/meta-leda-components/recipes-sdv/sdv-wifi/files/wpa.sh
@@ -18,8 +18,14 @@
 #   iw wlan0 info
 #   iw wlan0 scan
 #   iw wlan0 link
+# Note:
+# Existence of /boot/wpa_supplicant.conf will overwrite the one in /etc
 
-if [ ! -e /etc/wpa_supplicant.conf ]; then
+if [ -e /boot/wpa_supplicant.conf ]; then
+  mv /boot/wpa_suplicant.conf /etc
+fi
+
+if [ ! -e /etc/wpa_supplicant.conf ]
   exit
 fi
 


### PR DESCRIPTION
If /boot/wpa_supplicant.conf exists, it will be moved to /etc and Wi-Fi upon wpa.service will start to use this one
Note that  /etc/wpa_supplicant.conf will be overwritten