### PR TITLE
Soft real-time clock sync

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
@@ -19,8 +19,9 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://service.template \
+            file://service.sync.template \ 
             file://config.json \
-          "
+           "
 
 do_install:append() {
 
@@ -36,5 +37,16 @@ do_install:append() {
           -e 's,@KANTO_MANIFESTS_DIR@,${KANTO_MANIFESTS_DIR},g' \
           -i ${D}${CM_CFG_DD}/container-management/config.json
 
+        # service.template as service
+        install -d ${D}/${systemd_unitdir}/system
+        if "${@bb.utils.contains('DISTRO_FEATURES','timesync','true','false',d)}" ; then
+          install -m 0644 ${WORKDIR}/service.sync.template ${D}${systemd_unitdir}/system/container-management.service
+        else
+          install -m 0644 ${WORKDIR}/service.template ${D}${systemd_unitdir}/system/container-management.service
+        fi
+        # fill in the container management service template with the result configurations
+        sed -e 's,@CM_BIN_DD@,${bindir},g' \
+            -e 's,@CM_CFG_DD@,${sysconfdir},g' \
+        -i ${D}${systemd_unitdir}/system/container-management.service
     fi
 }

--- a/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
@@ -18,11 +18,9 @@
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;branch=main \
-            file://service.template \
+SRC_URI += "file://service.template \
             file://config.json \
           "
-SRCREV = "d7cea3ad4e7329d770da5c2d4ff4cc10629c0b80"
 
 do_install:append() {
 

--- a/meta-leda-components/recipes-sdv/eclipse-kanto/files/service.sync.template
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/files/service.sync.template
@@ -1,0 +1,14 @@
+[Unit]
+Description=Eclipse Kanto - Container Management
+Documentation=https://eclipse.org/kanto/docs/
+After=network-online.target systemd-timesyncd.service time-set.target containerd.service data.mount
+Requires=network-online.target containerd.service
+
+[Service]
+Type=simple
+ExecStart=@CM_BIN_DD@/container-management --cfg-file @CM_CFG_DD@/container-management/config.json
+Restart=always
+TimeoutSec=3000
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-leda-components/recipes-sdv/eclipse-kanto/files/service.template
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/files/service.template
@@ -1,7 +1,7 @@
 [Unit]
 Description=Eclipse Kanto - Container Management
 Documentation=https://eclipse.org/kanto/docs/
-After=network.target containerd.service data.mount
+After=network.target containerd.service time-set.target data.mount
 Requires=network.target containerd.service
 
 [Service]

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/README.md
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/README.md
@@ -1,0 +1,41 @@
+# soft-hwclock
+
+## description
+
+Many simple systems, such as the Raspberry PI, don't have hardware clocks.
+When they boot, they start with their system clock set at some fixed date, e.g. 2000/01/01 00:00:00.
+
+A _soft_ hwclock sets the initial time to some known value from before the last reboot.  This brings
+the clock into a _sensible_ range prior to getting a better value from network based services
+such as _ntp_.  Should the network not be available, services can continue to run from where they
+left off, avoiding problems with an internal clock set far in the past conflicting with recent
+timestamps.
+
+Some systems have packages to do womething similar, while others don't.  This repository consists of
+shell scripts and service files for _systemd_ based systems to achieve this, and has been
+tested on a Raspberry Pi 3 running CentOS 7
+
+## features
+
+Sets the time to a "recent" timestamp early in the boot to avoid timestamps
+far in the past when booting, prior to getting a proper timestamp from the network.
+
+- Restores the system clock from file during early boot
+- Saves the clock into a file at shutdown
+- Regularly saves the current time into the data file, in case of improper shutdown.
+- shell based to avoid platform and binary dependencies.
+- contains soft-hwclock.service and soft-hwclock.timer systemd units.
+
+## installation:
+
+1. copy these files into an empty folder, e.g. ```myfolder```.
+2. install the services:
+```cd myfolder; chmod +x install; ./install```
+This will install it into `/opt/soft-hwclock`, and the unit files into `/etc/systemd/system`.
+3. The install script has enabled and started the service, but you can also do it manually:
+```systemctl enable soft-hwclock.service && systemctl start soft-hwclock.service```
+
+## See also:
+This package is inspired by Steve McIntyre's [fake-hwclock package for Debian.][fake-hwclock]
+
+[fake-hwclock]: https://tracker.debian.org/pkg/fake-hwclock

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/LICENSE
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Kristján Valur Jónsson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Get the saved time (or empty) and clock time, in RFC399 format
+# This format sorts lexicographically
+
+CLOCKFILE="/opt/soft-hwclock/soft-hwclock.data"
+CTIME=$(date +%s)
+#CTIME=$(date --rfc-3339=seconds)
+FTIME=$(test -f "${CLOCKFILE}" && cat "${CLOCKFILE}")
+
+# if the file time is in the future, use that
+setclock() {
+	if expr "${FTIME}" \> "${CTIME}" ; then
+		echo "loading saved time ${FTIME} over ${CTIME}"
+		date --date @"${FTIME}"
+		#date --date="${FTIME}"
+		#echo would set clock to $FTIME
+	else
+		echo "ignoring saved time ${FTIME} over ${CTIME}"
+	fi
+}
+
+
+# if current time is greater than what is in the file, save it
+saveclock() {
+	if expr "${CTIME}" \> "${FTIME}" ; then
+		echo "saving time ${CTIME} over ${FTIME}"
+		echo "${CTIME}" > "${CLOCKFILE}"
+	else
+		echo "not saving time ${CTIME} over ${FTIME}"
+	fi
+}
+
+
+case "$1" in
+	load)
+		setclock
+		;;
+	save)
+		saveclock
+		;;
+	tick)
+		saveclock
+		;;
+	*)
+		echo "Usage: $0 {load|save|tick}"
+		exit 1
+		;;
+esac
+

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock-tick.service
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock-tick.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Save hwclock by timer
+
+[Service]
+Type=oneshot
+ExecStart=/opt/soft-hwclock/soft-hwclock tick > /dev/null

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock-tick.timer
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock-tick.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Save hwclock every 15 minutes
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=15min
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock.service
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/files/soft-hwclock.service
@@ -1,0 +1,25 @@
+# Fake hwclock service
+# No default dependencies to enable very early execution.  Depends only on local filesystem
+# Manually add shudtown.target dependency because no default.
+# pulls in time-sync.target (see man systemd.special)
+# Runs before the other time sync daemons, if they are being started
+# Removed from before section: ntpdate.service ntpd.service
+
+[Unit]
+Description=Fake Hardware Clock
+DefaultDependencies=No
+Requires=local-fs.target
+After=local-fs.target
+Wants=time-sync.target
+Conflicts=shutdown.target
+Before=shutdown.target time-sync.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/opt/soft-hwclock/soft-hwclock load
+ExecStop=/opt/soft-hwclock/soft-hwclock save
+
+[Install]
+WantedBy=multi-user.target
+Also=soft-hwclock-tick.timer

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
@@ -1,0 +1,58 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+DESCRIPTION = "Fake Hardware Clock"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append = " file://soft-hwclock"
+SRC_URI:append = " file://soft-hwclock.service"
+SRC_URI:append = " file://soft-hwclock-tick.service"
+SRC_URI:append = " file://soft-hwclock-tick.timer"
+
+SRC_URI = "https://github.com/kristjanvalur/soft-hwclock"
+SRC_URI[sha256sum] = "7400ec700fdd0487e0373430de69a2112cb09401bf54f60ce715bb91d61bf70b"
+
+inherit systemd features_check
+
+NATIVE_SYSTEMD_SUPPORT = "1"
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "soft-hwclock.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+PACKAGES = "${PN}"
+FILES:${PN} += "/opt/soft-hwclock/soft-hwclock"
+FILES:${PN} += "/opt/soft-hwclock/soft-hwclock.data"
+FILES:${PN} += "${systemd_unitdir}/system/soft-hwclock.service"
+FILES:${PN} += "${systemd_unitdir}/system/soft-hwclock-tick.service"
+FILES:${PN} += "${systemd_unitdir}/system/soft-hwclock-tick.timer"
+
+do_install:append() {
+
+    install -d ${D}/opt/soft-hwclock
+    install -m 0755 ${WORKDIR}/soft-hwclock ${D}/opt/soft-hwclock
+
+    CTIME=$(date +%s)
+    echo "${CTIME}" > ${D}/opt/soft-hwclock/soft-hwclock.data
+
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/soft-hwclock.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/soft-hwclock-tick.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/soft-hwclock-tick.timer ${D}${systemd_unitdir}/system
+
+}
+
+SRC_URI += "file://LICENSE"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=a109bd21357ed8a1fa56e8879764d28d"

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
@@ -20,7 +20,7 @@ SRC_URI:append = " file://soft-hwclock-tick.service"
 SRC_URI:append = " file://soft-hwclock-tick.timer"
 
 SRC_URI = "https://github.com/kristjanvalur/soft-hwclock"
-SRC_URI[sha256sum] = "7400ec700fdd0487e0373430de69a2112cb09401bf54f60ce715bb91d61bf70b"
+SRC_URI[sha256sum] = "7c54181ed4d593ce3ab5a598324db6f1c272508140f6099cc70bea9104f81881"
 
 inherit systemd features_check
 

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
@@ -20,7 +20,7 @@ SRC_URI:append = " file://soft-hwclock-tick.service"
 SRC_URI:append = " file://soft-hwclock-tick.timer"
 
 SRC_URI = "https://github.com/kristjanvalur/soft-hwclock"
-SRC_URI[sha256sum] = "7c54181ed4d593ce3ab5a598324db6f1c272508140f6099cc70bea9104f81881"
+SRC_URI[sha256sum] = "1268c4fee70172603845c4d305fbfc1b06f04a228d16515e7001d4f836b331e6"
 
 inherit systemd features_check
 

--- a/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
+++ b/meta-leda-components/recipes-sdv/sdv-soft-hwclock/soft-hwclock.bb
@@ -19,8 +19,8 @@ SRC_URI:append = " file://soft-hwclock.service"
 SRC_URI:append = " file://soft-hwclock-tick.service"
 SRC_URI:append = " file://soft-hwclock-tick.timer"
 
-SRC_URI = "https://github.com/kristjanvalur/soft-hwclock"
-SRC_URI[sha256sum] = "1268c4fee70172603845c4d305fbfc1b06f04a228d16515e7001d4f836b331e6"
+# SRC_URI = "https://github.com/kristjanvalur/soft-hwclock"
+# SRC_URI[sha256sum] = "1268c4fee70172603845c4d305fbfc1b06f04a228d16515e7001d4f836b331e6"
 
 inherit systemd features_check
 

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
@@ -26,6 +26,7 @@ IMAGE_INSTALL:append = " packagegroup-sdv-examples"
 IMAGE_INSTALL:append = " ${@bb.utils.contains("DISTRO_FEATURES", "wifi", "packagegroup-base-wifi", "", d)}"
 IMAGE_INSTALL:append:raspberrypi4-64 = " ${@bb.utils.contains("DISTRO_FEATURES", "wifi", "packagegroup-sdv-rpi4wifi", "", d)}"
 IMAGE_INSTALL:append:raspberrypi4-64 = " ${@bb.utils.contains("DISTRO_FEATURES", "wifi", "wpa-service", "", d)}"
+IMAGE_INSTALL:append:raspberrypi4-64 = " ${@bb.utils.contains("DISTRO_FEATURES", "timesync", "", "soft-hwclock", d)}"
 
 IMAGE_LINGUAS = " "
 

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-minimal.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-minimal.bb
@@ -22,6 +22,7 @@ IMAGE_INSTALL:append = " packagegroup-sdv-core"
 IMAGE_INSTALL:append = " ${@bb.utils.contains("DISTRO_FEATURES", "wifi", "packagegroup-base-wifi", "", d)}"
 IMAGE_INSTALL:append:raspberrypi4-64 = " ${@bb.utils.contains("DISTRO_FEATURES", "wifi", "packagegroup-sdv-rpi4wifi", "", d)}"
 IMAGE_INSTALL:append:raspberrypi4-64 = " ${@bb.utils.contains("DISTRO_FEATURES", "wifi", "wpa-service", "", d)}"
+IMAGE_INSTALL:append:raspberrypi4-64 = " ${@bb.utils.contains("DISTRO_FEATURES", "timesync", "", "soft-hwclock", d)}"
 
 IMAGE_LINGUAS = " "
 


### PR DESCRIPTION
Some components require a proper clock tick to function. The soft RTC ensures reasonable date and time.

This fixes containers not being able to deploy correctly when there is no hardware RTC available and network is not yet connected (e.g. unable to sync clock with NTP).

Only devices without HW RTC were affected (e.g. Raspberry Pi).

The advantage of this approach is that there is no need for waiting for NTP, so that we can deploy containers earlier in the boot phase.

