### PR TITLE
Container deployment manifest format migration and KAD taking over initdir

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-kanto/files/config.json
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/files/config.json
@@ -7,5 +7,8 @@
     },
     "things": {
         "enable": @CM_THINGS_ENABLED@
+    },
+    "deployment": {
+        "init_dir": "@KANTO_MANIFESTS_DIR@"
     }
 }

--- a/meta-leda-components/recipes-sdv/eclipse-kanto/files/config.json
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/files/config.json
@@ -7,8 +7,5 @@
     },
     "things": {
         "enable": @CM_THINGS_ENABLED@
-    },
-    "deployment": {
-        "init_dir": "@KANTO_MANIFESTS_DIR@"
     }
 }

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core/cloudconnector.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core/cloudconnector.json
@@ -1,16 +1,10 @@
 {
-    "id": "cloudconnector",
-    "name": "cloudconnector",
+    "container_id": "cloudconnector",
+    "container_name": "cloudconnector",
     "image": {
-        "name": "ghcr.io/eclipse-leda/leda-contrib-cloud-connector/cloudconnector:main-47c01227a620a3dbd85b66e177205c06c0f7a52e",
-        "decrypt_config": null
+        "name": "ghcr.io/eclipse-leda/leda-contrib-cloud-connector/cloudconnector:main-47c01227a620a3dbd85b66e177205c06c0f7a52e"
     },
-    "host_name": "",
-    "domain_name": "",
-    "resolv_conf_path": "",
-    "hosts_path": "",
-    "hostname_path": "",
-    "mounts": [
+    "mount_points": [
         {
             "source": "/data/var/certificates/device.crt",
             "destination": "/device.crt",
@@ -22,9 +16,7 @@
             "propagation_mode": "rprivate"
         }
     ],
-    "hooks": [],
     "host_config": {
-        "devices": [],
         "network_mode": "bridge",
         "privileged": false,
         "restart_policy": {
@@ -48,16 +40,7 @@
                 "mode": "blocking",
                 "max_buffer_size": ""
             }
-        },
-        "resources": null
-    },
-    "io_config": {
-        "attach_stderr": false,
-        "attach_stdin": false,
-        "attach_stdout": false,
-        "open_stdin": false,
-        "stdin_once": false,
-        "tty": false
+        }
     },
     "config": {
         "env": [
@@ -71,23 +54,5 @@
            "ALLOWED_LOCAL_TOPICS_LIST=cloudConnector/#"
         ],
         "cmd": []
-    },
-    "network_settings": null,
-    "state": {
-        "pid": -1,
-        "started_at": "",
-        "error": "",
-        "exit_code": 0,
-        "finished_at": "",
-        "exited": false,
-        "dead": false,
-        "restarting": false,
-        "paused": false,
-        "running": false,
-        "status": "",
-        "oom_killed": false
-    },
-    "created": "",
-    "manually_stopped": false,
-    "restart_count": 0
+    }
 }

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/feedercan.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/feedercan.json
@@ -15,7 +15,7 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [
-            "databroker-host:databroker"
+            "databroker:container_databroker-host"
         ],
         "log_config": {
             "driver_config": {
@@ -38,7 +38,7 @@
     "config": {
         "env": [
             "VEHICLEDATABROKER_DAPR_APP_ID=databroker",
-            "VDB_ADDRESS=databroker-host:30555",
+            "VDB_ADDRESS=databroker:55555",
             "USECASE=databroker",
             "LOG_LEVEL=info",
             "databroker=info",

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/feedercan.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/feedercan.json
@@ -15,7 +15,7 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [
-            "databroker-host:host_ip"
+            "databroker-host:databroker"
         ],
         "log_config": {
             "driver_config": {

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/hvac.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/hvac.json
@@ -15,7 +15,7 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [
-            "databroker-host:host_ip"
+            "databroker-host:databroker"
         ],
         "port_mappings": [],
         "log_config": {

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/hvac.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/hvac.json
@@ -15,7 +15,7 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [
-            "databroker-host:databroker"
+            "databroker:container_databroker-host"
         ],
         "port_mappings": [],
         "log_config": {
@@ -39,7 +39,7 @@
     "config": {
         "env": [
             "VEHICLEDATABROKER_DAPR_APP_ID=databroker",
-            "VDB_ADDRESS=databroker-host:30555"
+            "VDB_ADDRESS=databroker:55555"
         ],
         "cmd": []
     }

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/otelcol-sdv-agent.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/otelcol-sdv-agent.json
@@ -1,16 +1,10 @@
 {
-    "id": "otelcol-sdv-agent",
-    "name": "otelcol-sdv-agent",
+    "container_id": "otelcol-sdv-agent",
+    "container_name": "otelcol-sdv-agent",
     "image": {
-        "name": "ghcr.io/softwaredefinedvehicle/sdv-edge-otel/otelcol-sdv-ext:v0.0.1",
-        "decrypt_config": null
+        "name": "ghcr.io/softwaredefinedvehicle/sdv-edge-otel/otelcol-sdv-ext:v0.0.1"    
     },
-    "host_name": "",
-    "domain_name": "",
-    "resolv_conf_path": "",
-    "hosts_path": "",
-    "hostname_path": "",
-    "mounts": [
+    "mount_points": [
         {
             "source": "/",
             "destination": "/hostfs",
@@ -29,7 +23,6 @@
     ],
     "hooks": [],
     "host_config": {
-        "devices": [],
         "network_mode": "bridge",
         "privileged": false,
         "restart_policy": {
@@ -56,21 +49,8 @@
                 "max_files": 2,
                 "max_size": "1M",
                 "root_dir": ""
-            },
-            "mode_config": {
-                "mode": "blocking",
-                "max_buffer_size": ""
             }
-        },
-        "resources": null
-    },
-    "io_config": {
-        "attach_stderr": false,
-        "attach_stdin": false,
-        "attach_stdout": false,
-        "open_stdin": false,
-        "stdin_once": false,
-        "tty": false
+        }
     },
     "config": {
         "env": [
@@ -85,23 +65,5 @@
         "cmd": [
             "/otelcol-sdv --config=/relay.yaml"
         ]
-    },
-    "network_settings": null,
-    "state": {
-        "pid": -1,
-        "started_at": "",
-        "error": "",
-        "exit_code": 0,
-        "finished_at": "",
-        "exited": false,
-        "dead": false,
-        "restarting": false,
-        "paused": false,
-        "running": false,
-        "status": "",
-        "oom_killed": false
-    },
-    "created": "",
-    "manually_stopped": false,
-    "restart_count": 0
+    }
 }

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/otelcol-sdv-exporter.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/otelcol-sdv-exporter.json
@@ -1,19 +1,10 @@
 {
-    "id": "otelcol-sdv-exporter",
-    "name": "otelcol-sdv-exporter",
+    "container_id": "otelcol-sdv-exporter",
+    "container_name": "otelcol-sdv-exporter",
     "image": {
-        "name": "ghcr.io/softwaredefinedvehicle/sdv-edge-otel/otelcol-sdv-exporter:v0.0.1",
-        "decrypt_config": null
+        "name": "ghcr.io/softwaredefinedvehicle/sdv-edge-otel/otelcol-sdv-exporter:v0.0.1"
     },
-    "host_name": "",
-    "domain_name": "",
-    "resolv_conf_path": "",
-    "hosts_path": "",
-    "hostname_path": "",
-    "mounts": [],
-    "hooks": [],
     "host_config": {
-        "devices": [],
         "network_mode": "bridge",
         "privileged": false,
         "restart_policy": {
@@ -48,37 +39,11 @@
         },
         "resources": null
     },
-    "io_config": {
-        "attach_stderr": false,
-        "attach_stdin": false,
-        "attach_stdout": false,
-        "open_stdin": false,
-        "stdin_once": false,
-        "tty": false
-    },
     "config": {
         "env": [
            "RUST_LOG=info",
            "MQTT_BROKER_HOST=mosquitto"
         ],
         "cmd": []
-    },
-    "network_settings": null,
-    "state": {
-        "pid": -1,
-        "started_at": "",
-        "error": "",
-        "exit_code": 0,
-        "finished_at": "",
-        "exited": false,
-        "dead": false,
-        "restarting": false,
-        "paused": false,
-        "running": false,
-        "status": "",
-        "oom_killed": false
-    },
-    "created": "",
-    "manually_stopped": false,
-    "restart_count": 0
+    }
 }

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
@@ -1,17 +1,9 @@
 {
-    "id": "seatservice-example",
-    "name": "seatservice-example",
+    "container_id": "seatservice-example",
+    "container_name": "seatservice-example",
     "image": {
-        "name": "ghcr.io/boschglobal/kuksa.val.services/seat_service:v0.3.0",
-        "decrypt_config": null
+        "name": "ghcr.io/boschglobal/kuksa.val.services/seat_service:v0.3.0"
     },
-    "host_name": "",
-    "domain_name": "",
-    "resolv_conf_path": "",
-    "hosts_path": "",
-    "hostname_path": "",
-    "mounts": [],
-    "hooks": [],
     "host_config": {
         "devices": [],
         "network_mode": "bridge",
@@ -45,16 +37,7 @@
                 "mode": "blocking",
                 "max_buffer_size": ""
             }
-        },
-        "resources": null
-    },
-    "io_config": {
-        "attach_stderr": false,
-        "attach_stdin": false,
-        "attach_stdout": false,
-        "open_stdin": false,
-        "stdin_once": false,
-        "tty": false
+        }
     },
     "config": {
         "env": [
@@ -63,23 +46,5 @@
            "vehicle_data_broker=info"
         ],
         "cmd": []
-    },
-    "network_settings": null,
-    "state": {
-        "pid": -1,
-        "started_at": "",
-        "error": "",
-        "exit_code": 0,
-        "finished_at": "",
-        "exited": false,
-        "dead": false,
-        "restarting": false,
-        "paused": false,
-        "running": false,
-        "status": "",
-        "oom_killed": false
-    },
-    "created": "",
-    "manually_stopped": false,
-    "restart_count": 0
+    }
 }

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
@@ -15,7 +15,7 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [
-            "databroker-host:container_databroker-host"
+            "databroker:container_databroker-host"
         ],
         "port_mappings": [
             {
@@ -41,7 +41,7 @@
     },
     "config": {
         "env": [
-           "BROKER_ADDR=databroker-host:55555",
+           "BROKER_ADDR=databroker:55555",
            "RUST_LOG=info",
            "vehicle_data_broker=info"
         ],

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
@@ -15,7 +15,7 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [
-            "databroker-host:host_ip"
+            "databroker-host:databroker"
         ],
         "port_mappings": [
             {

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example/seatservice.json
@@ -15,7 +15,7 @@
         },
         "runtime": "io.containerd.runc.v2",
         "extra_hosts": [
-            "databroker-host:databroker"
+            "databroker-host:container_databroker-host"
         ],
         "port_mappings": [
             {
@@ -41,7 +41,7 @@
     },
     "config": {
         "env": [
-           "BROKER_ADDR=databroker-host:30555",
+           "BROKER_ADDR=databroker-host:55555",
            "RUST_LOG=info",
            "vehicle_data_broker=info"
         ],

--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
@@ -15,7 +15,7 @@ SUMMARY = "SDV Core Utilities"
 DESCRIPTION = "Core shell scripts for Eclipse Leda"
 
 SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
-SRCREV = "3f79a1abb1584501872f8d259f8d358c5e5919fd"
+SRCREV = "5f5b3ef2dd4f7da41a5dcbd8402f58b664abd006"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
@@ -26,20 +26,16 @@ SRC_URI:append = " file://core/cloudconnector.json"
 
 
 do_install:append() {
-    install -d ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${WORKDIR}/core/databroker.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${WORKDIR}/core/vum.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${WORKDIR}/core/sua.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${WORKDIR}/core/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/core/databroker.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/core/vum.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/core/sua.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/core/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 }
 
 PACKAGES = "${PN}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/databroker.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/vum.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/sua.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/cloudconnector.json"
-
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/databroker.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/vum.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/sua.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/cloudconnector.json"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
@@ -22,7 +22,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/kanto-containers:"
 SRC_URI:append = " file://core/databroker.json"
 SRC_URI:append = " file://core/vum.json"
 SRC_URI:append = " file://core/sua.json"
-SRC_URI:append = " file://core_dev/cloudconnector.json"
+SRC_URI:append = " file://core/cloudconnector.json"
 
 
 do_install:append() {
@@ -30,9 +30,9 @@ do_install:append() {
     install ${WORKDIR}/core/databroker.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
     install ${WORKDIR}/core/vum.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
     install ${WORKDIR}/core/sua.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/core_dev/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 }
 
 PACKAGES = "${PN}"
@@ -40,6 +40,6 @@ FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}"
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/databroker.json"
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/vum.json"
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/sua.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/cloudconnector.json"
 
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/cloudconnector.json"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb
@@ -26,16 +26,16 @@ SRC_URI:append = " file://core/cloudconnector.json"
 
 
 do_install:append() {
-    install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/core/databroker.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/core/vum.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/core/sua.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/core/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install -d ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/databroker.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/vum.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/sua.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/core/cloudconnector.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 }
 
 PACKAGES = "${PN}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/databroker.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/vum.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/sua.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/cloudconnector.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/databroker.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/vum.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/sua.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/cloudconnector.json"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
@@ -24,14 +24,13 @@ SRC_URI:append = " file://example/feedercan.json"
 SRC_URI:append = " file://example/seatservice.json"
 
 do_install:append() {
-    install -d ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${WORKDIR}/example/hvac.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${WORKDIR}/example/feedercan.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-    install ${WORKDIR}/example/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/example/hvac.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/example/feedercan.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install ${WORKDIR}/example/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+
 # Under construction
 #   install ${WORKDIR}/example/zipkin.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
-
-    install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 # Under construction
 #    install ${WORKDIR}/example_dev/otelcol-sdv-agent.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 #    install ${WORKDIR}/example_dev/otelcol-sdv-exporter.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
@@ -39,14 +38,13 @@ do_install:append() {
 }
 
 PACKAGES = "${PN}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/hvac.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/feedercan.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/seatservice.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/hvac.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/feedercan.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/seatservice.json"
 # Under construction
 # FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/zipkin.json"
 
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}"
 # Under construction
 # FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/otelcol-sdv-agent.json"
 # FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/otelcol-sdv-exporter.json"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
@@ -21,17 +21,17 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd
 FILESEXTRAPATHS:prepend := "${THISDIR}/kanto-containers:"
 SRC_URI:append = " file://example/hvac.json"
 SRC_URI:append = " file://example/feedercan.json"
-SRC_URI:append = " file://example_dev/seatservice.json"
+SRC_URI:append = " file://example/seatservice.json"
 
 do_install:append() {
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DIR}
     install ${WORKDIR}/example/hvac.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
     install ${WORKDIR}/example/feedercan.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/example/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 # Under construction
 #   install ${WORKDIR}/example/zipkin.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 
     install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/example_dev/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 # Under construction
 #    install ${WORKDIR}/example_dev/otelcol-sdv-agent.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
 #    install ${WORKDIR}/example_dev/otelcol-sdv-exporter.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
@@ -42,11 +42,11 @@ PACKAGES = "${PN}"
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}"
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/hvac.json"
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/feedercan.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/seatservice.json"
 # Under construction
 # FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/zipkin.json"
 
 FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/seatservice.json"
 # Under construction
 # FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/otelcol-sdv-agent.json"
 # FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/otelcol-sdv-exporter.json"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb
@@ -24,10 +24,10 @@ SRC_URI:append = " file://example/feedercan.json"
 SRC_URI:append = " file://example/seatservice.json"
 
 do_install:append() {
-    install -d ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/example/hvac.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/example/feedercan.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
-    install ${WORKDIR}/example/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DEV_DIR}
+    install -d ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/example/hvac.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/example/feedercan.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
+    install ${WORKDIR}/example/seatservice.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
 
 # Under construction
 #   install ${WORKDIR}/example/zipkin.json ${D}${KANTO_MANIFESTS_LOCAL_DIR}
@@ -38,10 +38,10 @@ do_install:append() {
 }
 
 PACKAGES = "${PN}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/hvac.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/feedercan.json"
-FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DEV_DIR}/seatservice.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/hvac.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/feedercan.json"
+FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/seatservice.json"
 # Under construction
 # FILES:${PN} += "${KANTO_MANIFESTS_LOCAL_DIR}/zipkin.json"
 


### PR DESCRIPTION
# Issues

1) The kanto-CM initdir mechanism currently is not stable and has very limited capabilities
2) We currently have two different manifest formats - KAD and initdir format - confusing for clients, support burden
3) Having initdir and KAD try to deploy the same manifests at the same time (startup) leads to race conditions.
4) Container-to-container extra host mappings now go trough the host-ip, which breaks isolation

# Solution

## 1 + 2

KAD now supports both manifest formats through the manifest_parser module. 

All container manifests have been converted to the "initdir" format documented in the official Kanto-CM docs.

The only two directories in meta-leda containing manifests are `meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/core` and `meta-leda-components/recipes-sdv/eclipse-leda/kanto-containers/example`

That the manifests are parsed correctly by KAD has been verified manually with the debug logs of KAD.

## 3

It was decided to only use KAD for now, until initdir is stablized. That's why:

1) The two recipes
`meta-leda-components/recipes-sdv/eclipse-leda/sdv-core-containers.bb` and `meta-leda-components/recipes-sdv/eclipse-leda/sdv-example-containers.bb` have been changed to point to install all manifests only in the path defined by `KANTO_MANIFESTS_LOCAL_DIR` (on leda-disto: /data/var/containers/manifests)

2) *LEDA DISTRO ONLY*: 

Remove in the local.conf:
KANTO_MANIFESTS_DIR <- used by initdir

Change in the local.conf:

KANTO_MANIFESTS_DEV_DIR = "/data/var/containers/manifests" <- was manifests_dev before


Effectively this disabled the initdir without having to remove all the recipes (as we should switch back to it once it's stabilized)


## 4 

Referencing the kanto-cm docs the extra-host mappings have been updated to container-to-container networking.


# TODO in other repositories:

## Leda-distro: 

**Done** in https://github.com/eclipse-leda/leda-distro/pull/61


Change local_conf_header in `common-kirkstone.yaml` to:

```yaml
local_conf_header:
  meta-leda: |
    INHERIT += "rm_work"
    INHERIT:remove = " archiver"
    INHERIT:remove = " cve-check"
    INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
    KANTO_MANIFESTS_DEV_DIR = "/data/var/containers/manifests"
``` 

## Leda-utils: 

**Done** in https://github.com/eclipse-leda/leda-utils/pull/34

Change sdv-provision to look for cloudconnector.json in `/data/var/containers/manifests`. It was tested with that change  made locally and the cloudconnector was able to talk to the azure hub after provisioning.


