### PR TITLE
Jetson Nano 2GB Devkit configurational files

### DIFF
--- a/meta-leda-bsp/conf/machine/jetson-nano-2gb-devkit-extra.conf
+++ b/meta-leda-bsp/conf/machine/jetson-nano-2gb-devkit-extra.conf
@@ -1,0 +1,14 @@
+#@TYPE: Machine
+#@NAME: Nvidia Jetson Nano 2GB Dev Kit
+#@DESCRIPTION: Nvidia Jetson Nano 2GB development kit
+
+# Allow the root partition to grow to the size of the SD Card
+#IMAGE_INSTALL:append = " e2fsprogs-resize2fs"
+#IMAGE_INSTALL:append = " gptfdisk"
+#IMAGE_INSTALL:append = " sdv-growdisk" (sdv-raspberry-growdisk)
+
+# Tegra needs a plain WIC file (not qcow2) to be flashed to SD-Card
+#WKS_FILE ?= "jetson-nano-2gb-devkit.wks"
+#IMAGE_FSTYPES = "tegraflash tar.gz wic.gz"
+
+#IMAGE_BOOT_FILES = "Image u-boot.bin tegra210-p3448-0003-p3542-0000-jetson-nano-2gb-devkit.dtb u-boot-jetson-nano-2gb-devkit.bin"

--- a/meta-leda-distro/recipes-core/base-files/base-files/jetson-nano-2gb-devkit/fstab
+++ b/meta-leda-distro/recipes-core/base-files/base-files/jetson-nano-2gb-devkit/fstab
@@ -1,0 +1,12 @@
+# Eclipse Leda - fstab for jetson-nano-2gb-devkit RAUC redundant boot setup
+
+/dev/root            /                    auto       defaults,noatime              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+# Add mount for boot, grubenv and data partition
+LABEL=boot           /boot                auto       defaults,nofail,noatime  0  0
+LABEL=grubenv        /grubenv             auto       defaults,nofail,noatime  0  0
+LABEL=data           /data                auto       defaults,nofail,noatime  0  2

--- a/meta-leda-distro/wic/jetson-nano-2gb-devkit.cfg
+++ b/meta-leda-distro/wic/jetson-nano-2gb-devkit.cfg
@@ -1,0 +1,36 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+menu title Eclipse Leda (Jetson Nano)
+
+timeout 50
+
+default sdv-full
+
+# vda2 = rescue
+# vda3 = full
+# vda4 = minimal
+# vda5 = data
+
+label sdv-full
+    menu label SDV Full (with tools)
+    kernel /Image
+    append root=/dev/mmcblk0p4 console=ttyS0,115200 net.ifnames=0 panic=5 ip=dhcp ip=192.168.7.2::192.168.7.1:255.255.255.0 rootwait rauc.slot=SDV_A
+label sdv-minimal
+    menu label SDV Minimal
+    kernel /Image
+    append root=/dev/mmcblk0p5 console=ttyS0,115200 net.ifnames=0 panic=5 ip=dhcp ip=192.168.7.2::192.168.7.1:255.255.255.0 rootwait rauc.slot=SDV_B
+label sdv-rescue
+    menu label SDV Rescue
+    kernel /Image
+    append root=/dev/mmcblk0p3 console=ttyS0,115200 net.ifnames=0 panic=5 ip=dhcp ip=192.168.7.2::192.168.7.1:255.255.255.0 rootwait rauc.external

--- a/meta-leda-distro/wic/jetson-nano-2gb-devkit.wks
+++ b/meta-leda-distro/wic/jetson-nano-2gb-devkit.wks
@@ -1,0 +1,41 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+#
+# Do not add mount points in the Kickstarter File, as we're using a custom fstab.
+# Otherwise, mount points will appear twice in fstab.
+#
+# short-description: Create SD card image
+# long-description: Creates an SD card image for jetson-nano
+
+
+# Bootloader configuration (U-Boot)
+bootloader --ptable gpt --configfile="jetson-nano-2gb-devkit.cfg"
+
+# /dev/mmcblk0p1 - Boot partition /boot
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 100
+
+# GRUB environment to store info about retries, mounted for showcase
+# /dev/mmcblk0p2 - Partition mounted to /grubenv
+part --fixed-size 10M --fstype=vfat --ondisk mmcblk0 --label grubenv --align 1024
+
+# /dev/mmcblk0p3 - Rescue partition
+part --source rootfs --rootfs-dir=sdv-image-rescue --ondisk mmcblk0 --fstype=ext4 --label rescue --align 1024
+
+# /dev/mmcblk0p4 - SDV Full partition - mounted to "/"
+part --source rootfs --rootfs-dir=sdv-image-full --ondisk mmcblk0 --fstype=ext4 --label root_a --align 4096
+
+# /dev/mmcblk0p5 - SDV Minimal partition
+part --source rootfs --rootfs-dir=sdv-image-minimal  --ondisk mmcblk0 --fstype=ext4 --label root_b --align 4096
+
+# /dev/mmcblk0p6 - Kanto Container Management Data partition mounted to "/data"
+part --fixed-size 2048M --source rootfs --rootfs-dir=sdv-image-data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --fsoptions "x-systemd.growfs"


### PR DESCRIPTION
Added:

- meta-leda-bsp/conf/machine/jetson-nano-2gb-devkit-extra.conf (for future implementations)
- meta-leda-distro/recipes-core/base-files/base-files/jetson-nano-2gb-devkit/fstab
- meta-leda-distro/wic/jetson-nano-2gb-devkit.cfg
- meta-leda-distro/wic/jetson-nano-2gb-devkit.wks