### PR TITLE
Remove gitsm fetcher and replace them with multiple git sources

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-kuksa/databroker-cli_0.17.0.bb
@@ -15,13 +15,19 @@
 #
 inherit cargo
 
-# If this is git based prefer versioned ones if they exist
-# DEFAULT_PREFERENCE = "-1"
 
-# how to get databroker-cli could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/databroker-cli/0.17.0"
-SRC_URI += "gitsm://github.com/eclipse/kuksa.val;protocol=https;nobranch=1"
-SRCREV = "590198a35de7b2201bdd913750157bb9778a5214"
+SRCREV_FORMAT = "cli_jsoncons_jwtcpp_turtle"
+
+SRC_URI += "git://github.com/eclipse/kuksa.val;branch=master;name=cli;protocol=https;nobranch=1 \
+            git://github.com/danielaparker/jsoncons.git;protocol=https;name=jsoncons;branch=master;destsuffix=git/kuksa-val-server/3rd-party-libs/jsoncons \
+            git://github.com/Thalhammer/jwt-cpp.git;protocol=https;name=jwtcpp;branch=master;destsuffix=git/kuksa-val-server/3rd-party-libs/jwt-cpp \
+            git://github.com/mat007/turtle.git;protocol=https;name=turtle;branch=master;destsuffix=git/kuksa-val-server/3rd-party-libs/turtle \
+            "
+SRCREV_cli = "590198a35de7b2201bdd913750157bb9778a5214"
+SRCREV_jsoncons = "af61925bb960df55331d3b6ec198042a1b133694"
+SRCREV_jwtcpp = "34bb0644ea613cfcbc09c148db9de8aa6c5612b5"
+SRCREV_turtle = "bbe01e6d9d21ff7075aba782434185a8339d44dd"
+
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "kuksa_databroker/databroker-cli"
 PV:append = ".AUTOINC+861b2ec674"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
@@ -26,10 +26,12 @@ inherit cargo kanto-auto-deployer
 RDEPENDS_${PN} += " grpc protobuf nativesdk-protobuf"
 DEPENDS += " protobuf protobuf-native grpc git-native"
 
-SRCREV = "cead2d028fb011f124b0f321e2c3a7c4e1845c12"
 PV:append = ".AUTOINC+cead2d028f"
-SRC_URI = "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
-SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;nobranch=1;name=containerm;destsuffix=src/rust/kanto-auto-deployer/container-management/containerm"
+SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
+SRCREV = "cead2d028fb011f124b0f321e2c3a7c4e1845c12"
+
+# Fetch the Kanto Container Management repository since kanto-auto-deployer needs the protobuf files from kanto CM
+SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;nobranch=1;name=containerm;destsuffix=git/src/rust/kanto-auto-deployer/container-management"
 SRCREV_containerm = "6e7c13a83473153c954f81fd89cfd3ad8ee94471"
 
 S = "${WORKDIR}/git"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
@@ -26,9 +26,11 @@ inherit cargo kanto-auto-deployer
 RDEPENDS_${PN} += " grpc protobuf nativesdk-protobuf"
 DEPENDS += " protobuf protobuf-native grpc git-native"
 
+SRCREV_FORMAT = "kadsrc_containerm"
+
 PV:append = ".AUTOINC+cead2d028f"
-SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "cead2d028fb011f124b0f321e2c3a7c4e1845c12"
+SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;name=kadsrc;branch=main"
+SRCREV_kadsrc = "cead2d028fb011f124b0f321e2c3a7c4e1845c12"
 
 # Fetch the Kanto Container Management repository since kanto-auto-deployer needs the protobuf files from kanto CM
 SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;nobranch=1;name=containerm;destsuffix=git/src/rust/kanto-auto-deployer/container-management"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
@@ -28,7 +28,9 @@ DEPENDS += " protobuf protobuf-native grpc git-native"
 
 SRCREV = "cead2d028fb011f124b0f321e2c3a7c4e1845c12"
 PV:append = ".AUTOINC+cead2d028f"
-SRC_URI = "gitsm://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
+SRC_URI = "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
+SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;nobranch=1;name=containerm;destsuffix=src/rust/kanto-auto-deployer/container-management/containerm"
+SRCREV_containerm = "6e7c13a83473153c954f81fd89cfd3ad8ee94471"
 
 S = "${WORKDIR}/git"
 

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kantui_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kantui_git.bb
@@ -22,9 +22,13 @@ inherit cargo
 RDEPENDS_${PN} += "grpc protobuf nativesdk-protobuf"
 DEPENDS += "protobuf protobuf-native grpc"
 
-SRC_URI += "gitsm://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
+SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
 SRCREV = "5bcbef1054775e277117d9cebacbc05234919ba7"
 PV:append = ".AUTOINC+5bcbef1054"
+
+# Fetch the Kanto Container Management repository since kantui needs the protobuf files from kanto CM
+SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;nobranch=1;name=containerm;destsuffix=git/src/rust/kanto-tui/container-management"
+SRCREV_containerm = "6e7c13a83473153c954f81fd89cfd3ad8ee94471"
 
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "src/rust/kanto-tui"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kantui_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kantui_git.bb
@@ -22,8 +22,10 @@ inherit cargo
 RDEPENDS_${PN} += "grpc protobuf nativesdk-protobuf"
 DEPENDS += "protobuf protobuf-native grpc"
 
-SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "5bcbef1054775e277117d9cebacbc05234919ba7"
+SRCREV_FORMAT = "kantuisrc_containerm"
+
+SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;name=kantuisrc;branch=main"
+SRCREV_kantuisrc = "5bcbef1054775e277117d9cebacbc05234919ba7"
 PV:append = ".AUTOINC+5bcbef1054"
 
 # Fetch the Kanto Container Management repository since kantui needs the protobuf files from kanto CM

--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-contrib-self-update-agent_git.bb
@@ -15,8 +15,29 @@ SUMMARY = "Self Update Agent offers remote OS updates for edge devices using RAU
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a832eda17114b48ae16cda6a500941c2"
 
-SRC_URI = "gitsm://github.com/eclipse-leda/leda-contrib-self-update-agent.git;protocol=https;branch=main"
-SRCREV = "f37df38cde19ef7974a8ceeb2b4f4dbbf288f43f"
+SRCREV_FORMAT = "sua_pahoc_pahoccp_yaml_curl_googletest_glib_spdlog_openssl_json"
+
+SRC_URI += "git://github.com/eclipse-leda/leda-contrib-self-update-agent.git;name=sua;protocol=https;branch=main \
+            git://github.com/eclipse/paho.mqtt.c.git;protocol=https;name=pahoc;branch=master;destsuffix=git/3rdparty/paho.mqtt.c \
+            git://github.com/eclipse/paho.mqtt.cpp.git;protocol=https;name=pahocpp;branch=master;destsuffix=git/3rdparty/paho.mqtt.cpp \
+            git://github.com/jimmiebergmann/mini-yaml.git;protocol=https;name=yaml;branch=master;destsuffix=git/3rdparty/mini-yaml \
+            git://github.com/curl/curl.git;protocol=https;name=curl;branch=master;destsuffix=git/3rdparty/curl \
+            git://github.com/google/googletest.git;protocol=https;name=googletest;branch=main;destsuffix=git/3rdparty/googletest \
+            git://github.com/GNOME/glib.git;protocol=https;name=glib;branch=main;destsuffix=git/3rdparty/glib \
+            git://github.com/gabime/spdlog.git;protocol=https;name=spdlog;branch=v1.x;destsuffix=git/3rdparty/spdlog \
+            git://github.com/openssl/openssl.git;protocol=https;name=openssl;branch=master;destsuffix=git/3rdparty/openssl \
+            git://github.com/nlohmann/json.git;protocol=https;name=json;branch=develop;destsuffix=git/3rdparty/nlohmann-json \
+            "
+SRCREV_sua = "f37df38cde19ef7974a8ceeb2b4f4dbbf288f43f"
+SRCREV_pahoc = "556cd568345e47b70da603edc92f11ff94a6161f"
+SRCREV_pahocpp = "2ff3d155dcd10564f1816675789284b4efd79eb7"
+SRCREV_yaml = "22d3dcf5684a11f9c0508c1ad8b3282a1d888319"
+SRCREV_curl = "a8e02881ec9417706610443bcfee6e1104bb44c6"
+SRCREV_googletest = "9c332145b71c36a5bad9688312c79184f98601ff"
+SRCREV_glib = "da2702646c1065eaa2d501a7f33776dcc2f0f11c"
+SRCREV_spdlog = "4f800773393d3ebac13c1fcd946a315d4d72bcd9"
+SRCREV_openssl = "a275afc527d05b5187b457bdbcd0e1dcb18839f1"
+SRCREV_json = "7f72eedc2d4fc196d389f5aa0b2659f70dabe278"
 
 SRC_URI += " \
     file://self-update-agent/self-update-agent.service \
@@ -29,7 +50,7 @@ S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig systemd
 
-EXTRA_OECMAKE += "-DSUA_COMMIT_HASH=${SRCREV} -DSUA_BUILD_NUMBER=${PR}"
+EXTRA_OECMAKE += "-DSUA_COMMIT_HASH=${SRCREV_sua} -DSUA_BUILD_NUMBER=${PR}"
 
 DEPENDS += "curl"
 DEPENDS += "dbus-glib"


### PR DESCRIPTION
We are currently in the process of doing license scanning with the oniro IP toolchain. The gitsm bitbake fetcher has known issues that prevent proper integration with IP scanning toolchains and source mirroring infra.

That's why all 4 recipes (KAD, kantui, SUA and databroker-cli) that use gitsm have been updated to use multiple git fetchers that download the submodules to the correct directories (checked against the .gitmodules files for each main repository).

All main sources and gitmodules now have fixed (static) SRCREV_/name/ set ensuring more reproducible builds.