### PR TITLE
Bugfix: Set container management recipe to a static SRCREV

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/container-management_%.bbappend
@@ -21,7 +21,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += "file://service.template \
             file://config.json \
            "
-SRCREV = "6e7c13a83473153c954f81fd89cfd3ad8ee94471"
+SRCREV="65e00358fa5aed1792059488a80fe755b36a8191"        
 
 do_install:append() {
 

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kanto-auto-deployer_git.bb
@@ -29,12 +29,12 @@ DEPENDS += " protobuf protobuf-native grpc git-native"
 SRCREV_FORMAT = "kadsrc_containerm"
 
 PV:append = ".AUTOINC+cead2d028f"
-SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;name=kadsrc;branch=main"
+SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;name=kadsrc;branch=main"
 SRCREV_kadsrc = "cead2d028fb011f124b0f321e2c3a7c4e1845c12"
 
 # Fetch the Kanto Container Management repository since kanto-auto-deployer needs the protobuf files from kanto CM
-SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;nobranch=1;name=containerm;destsuffix=git/src/rust/kanto-auto-deployer/container-management"
-SRCREV_containerm = "6e7c13a83473153c954f81fd89cfd3ad8ee94471"
+SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;branch=main;name=containerm;destsuffix=git/src/rust/kanto-auto-deployer/container-management"
+SRCREV_containerm = "65e00358fa5aed1792059488a80fe755b36a8191"
 
 S = "${WORKDIR}/git"
 

--- a/meta-leda-components/recipes-sdv/eclipse-leda/kantui_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/kantui_git.bb
@@ -24,13 +24,13 @@ DEPENDS += "protobuf protobuf-native grpc"
 
 SRCREV_FORMAT = "kantuisrc_containerm"
 
-SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;nobranch=1;name=kantuisrc;branch=main"
+SRC_URI += "git://github.com/eclipse-leda/leda-utils.git;protocol=https;name=kantuisrc;branch=main"
 SRCREV_kantuisrc = "5bcbef1054775e277117d9cebacbc05234919ba7"
 PV:append = ".AUTOINC+5bcbef1054"
 
 # Fetch the Kanto Container Management repository since kantui needs the protobuf files from kanto CM
-SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;nobranch=1;name=containerm;destsuffix=git/src/rust/kanto-tui/container-management"
-SRCREV_containerm = "6e7c13a83473153c954f81fd89cfd3ad8ee94471"
+SRC_URI += "git://github.com/eclipse-kanto/container-management;protocol=https;branch=main;name=containerm;destsuffix=git/src/rust/kanto-tui/container-management"
+SRCREV_containerm = "65e00358fa5aed1792059488a80fe755b36a8191"
 
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "src/rust/kanto-tui"


### PR DESCRIPTION
The container management recipe has been using the ${AUTOREV}  variable for SRCREV (latest commit). This leads to clean (no sstate/mirros)builds breaking due to update in either moby or runc version. 

The commit hash for container-management has been set to a known good revision of `65e00358fa5aed1792059488a80fe755b36a8191` of the main branch.

To keep recipes in sync kantui and kanto-auto-deployer have also been set to use the same hash `SRCREV_containerm=65e00358fa5aed1792059488a80fe755b36a8191`.

With these changes a clean (no-sttate/mirrors) build compiles fine and all containers are deployed with working container-to-container networking.
