### PR TITLE
Remove skopeo dependency from packagegroup-sdv-tools.bb

### DIFF
--- a/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-tools.bb
+++ b/meta-leda-components/recipes-sdv/packagegroups/packagegroup-sdv-tools.bb
@@ -22,7 +22,6 @@ RDEPENDS:${PN} = "\
     kibi \
     mosquitto-clients \
     leda-utils \
-    skopeo \
     sudo \
     databroker-cli \
     "


### PR DESCRIPTION
We only need _skopeo_ at build time to pull containers, not in the final image.