### PR TITLE
HOTFIX: add SRCREV_FORMAT order to kibi recipe

### DIFF
--- a/meta-leda-components/recipes-sdv/leda-tools/kibi_0.2.2.bb
+++ b/meta-leda-components/recipes-sdv/leda-tools/kibi_0.2.2.bb
@@ -17,8 +17,10 @@ HOMEPAGE = "https://github.com/ilai-deutel/kibi"
 
 inherit cargo
 
-SRC_URI += "git://github.com/ilai-deutel/kibi.git;protocol=https;nobranch=1"
-SRCREV = "2cc6bead72e2b48203d6ddf28f189c51868a9a79"
+SRCREV_FORMAT = "kibisrc_moresyntax"
+
+SRC_URI += "git://github.com/ilai-deutel/kibi.git;protocol=https;nobranch=1;protocol=https;name=kibisrc;branch=main"
+SRCREV_kibisrc = "2cc6bead72e2b48203d6ddf28f189c51868a9a79"
 
 # Get a commit with syntax highlighting for a lot of languages but no support for rust version 1.59.0
 SRC_URI += "git://github.com/ilai-deutel/kibi.git;protocol=https;nobranch=1;name=moresyntax;destsuffix=moresyntax/"

--- a/meta-leda-components/recipes-sdv/leda-tools/kibi_0.2.2.bb
+++ b/meta-leda-components/recipes-sdv/leda-tools/kibi_0.2.2.bb
@@ -19,7 +19,7 @@ inherit cargo
 
 SRCREV_FORMAT = "kibisrc_moresyntax"
 
-SRC_URI += "git://github.com/ilai-deutel/kibi.git;protocol=https;nobranch=1;protocol=https;name=kibisrc;branch=main"
+SRC_URI += "git://github.com/ilai-deutel/kibi.git;nobranch=1;protocol=https;name=kibisrc;branch=main"
 SRCREV_kibisrc = "2cc6bead72e2b48203d6ddf28f189c51868a9a79"
 
 # Get a commit with syntax highlighting for a lot of languages but no support for rust version 1.59.0


### PR DESCRIPTION
BitBake needs to know the order in which the pull sources when there are multiple SRCREV fetchers:
https://docs.yoctoproject.org/bitbake/2.2/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-SRCREV_FORMAT

Kibi recipe was lacking this before, leading to recipes building sometimes but failing for other users of meta-leda.