### PR TITLE
Account for renamed UM binary

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-kanto/files/update-manager/config.json
+++ b/meta-leda-components/recipes-sdv/eclipse-kanto/files/update-manager/config.json
@@ -1,6 +1,6 @@
 {
     "log": {
-      "logFile": "/var/log/update-manager/update-manager.log"
+      "logFile": "/var/log/kanto-update-manager/kanto-update-manager.log"
     },
     "domain": "vehicle",
     "agents": {


### PR DESCRIPTION
Update manager has been renamed to kanto-update-manager. Set the log file path accordingly  to account for the new name.