### PR TITLE
Fix workspace ownership in codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 # Install Dependencies
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends socat file gawk wget git diffstat unzip texinfo \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends socat file gawk wget acl git diffstat unzip texinfo \
         gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils \
         iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit \ 
         mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq \

--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -20,6 +20,13 @@
 sudo chown root:kvm /dev/kvm
 sudo chmod 0660 /dev/kvm
 
+function take_workspace_ownership() {
+    local USER=$1
+    local DIR=$2
+    sudo chown -R ${USER} ${DIR}
+    sudo setfacl -bnR ${DIR}
+}
+
 # Optional: Mount Azure Storage as remote sstate-cache to improve build time.
 # This is only required if you want to manually upload / sync build artifacts to your remote sstate-cache
 # To configure the sstate-cache and upload local build artifacts, the following environment variables need to be set:
@@ -44,8 +51,15 @@ function azure-mount() {
     fi
 }
 
+
 # First arg: local mount point
 # Second arg: Name of Azure container
 azure-mount "azure-sstate-cache" "yocto-sstate-cache"
 azure-mount "azure-downloads-cache" "downloads"
 
+# There is a umask issue in GitHub codespaces
+# possibly related to: https://github.com/orgs/community/discussions/26026
+# which causes some recipes to fail to build, due to wrong permissions (e.g. gpsd)
+if [ -n "$CODESPACE_VSCODE_FOLDER" ]; then 
+    take_dir_ownership $(whoami)  ${CODESPACE_VSCODE_FOLDER}
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 # Metalayer folders are created by running "kas build" and we don't
 # want to commit them as git submodules.
 meta-kanto
+meta-lts-mixins
 meta-openembedded
 meta-rauc
 meta-rauc-community


### PR DESCRIPTION
Workspace ownership issues lead to some recipes (i.e. gpsd) failing to compile. This PR address that through the post-attach script.